### PR TITLE
週次リファクタリング 2026-04-20

### DIFF
--- a/agent/gmail_handler.py
+++ b/agent/gmail_handler.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 _PROCESSED_IDS_FILE = "data/processed_ids.txt"
 _GMAIL_QUERY = "is:unread in:inbox -category:promotions"
+_MAX_MESSAGES_PER_RUN = 200
 
 
 def _parse_headers(payload: dict) -> dict[str, str]:
@@ -206,7 +207,7 @@ def notify_unread_emails():
 
 
 def _archive_message(service, msg_id: str):
-    """メールを受信トレイから削除（アーカイブ）する。"""
+    """メールを受信トレイからアーカイブする。"""
     service.users().messages().modify(
         userId="me", id=msg_id, body={"removeLabelIds": ["INBOX"]}
     ).execute()
@@ -253,11 +254,8 @@ def _add_label(service, msg_id: str, label_id: str):
         logger.exception(f"Failed to add label to message {msg_id}")
 
 
-_MAX_MESSAGES_PER_RUN = 200
-
-
 def _list_all_messages(service, query: str, max_results: int) -> list[dict]:
-    """ページネーションで全未読メッセージを取得する（上限 max_results 件）。"""
+    """ページネーションで Gmail メッセージを一括取得する。"""
     messages = []
     page_token = None
     while len(messages) < max_results:


### PR DESCRIPTION
## サマリー
修正完了です。

**実施した修正：**
- `_MAX_MESSAGES_PER_RUN` をファイル上部の定数群（28行目）に移動
- `_list_all_messages` の docstring から冗長な「(上限 max_results 件)」を削除
- `_archive_message` の docstring「削除（アーカイブ）」→「アーカイブ」に修正

**スキップした指摘：**
- `while` + `break` の二重ガード → 両条件は独立（上限チェック vs ページ終端）なので問題なし
- `notify_unread_emails` のデッドコード → 軽量な手動確認用途の可能性があるため、削除は判断を委ねます

## 変更ファイル
- `agent/gmail_handler.py`