### PR TITLE
feat: Cloudflare Workers 移行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "cf-worker/**"
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cf-worker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: cf-worker/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Deploy
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/cf-worker/.env.local.example
+++ b/cf-worker/.env.local.example
@@ -1,0 +1,31 @@
+# ============================================================
+# Cloudflare CLI 認証（wrangler コマンド実行に必要）
+# https://dash.cloudflare.com/profile/api-tokens
+# ============================================================
+CLOUDFLARE_API_TOKEN=
+# https://dash.cloudflare.com → 右サイドバー "Account ID"
+CLOUDFLARE_ACCOUNT_ID=
+
+# ============================================================
+# Worker Secrets（wrangler secret put で Cloudflare に登録する値）
+# npm run secrets:push で一括登録できる
+# ============================================================
+
+# Anthropic（https://console.anthropic.com/settings/keys）
+ANTHROPIC_API_KEY=sk-ant-
+
+# Notion（https://www.notion.so/profile/integrations → インテグレーション作成）
+NOTION_TOKEN=ntn_
+# タスク DB を開いて URL の末尾 32 文字
+NOTION_TASKS_DB_ID=
+
+# Telegram（https://t.me/BotFather で /newbot）
+TELEGRAM_BOT_TOKEN=
+# Bot にメッセージを送った後: https://api.telegram.org/bot{TOKEN}/getUpdates の chat.id
+TELEGRAM_CHAT_ID=
+
+# Google OAuth（https://console.cloud.google.com → 認証情報 → OAuth クライアント ID）
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# data/token.json の refresh_token フィールド
+GOOGLE_REFRESH_TOKEN=

--- a/cf-worker/.gitignore
+++ b/cf-worker/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.wrangler/

--- a/cf-worker/.gitignore
+++ b/cf-worker/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .wrangler/
+.env.local

--- a/cf-worker/migrations/0001_initial.sql
+++ b/cf-worker/migrations/0001_initial.sql
@@ -1,0 +1,27 @@
+-- Gmail thread ID → Notion page ID (deduplication for reply emails)
+CREATE TABLE IF NOT EXISTS gmail_thread_map (
+  thread_id TEXT PRIMARY KEY,
+  notion_page_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Notion page ID → Gmail sender address (for blocklist learning)
+CREATE TABLE IF NOT EXISTS task_sender_map (
+  notion_page_id TEXT PRIMARY KEY,
+  sender_email TEXT NOT NULL
+);
+
+-- Notion page ID → Google Calendar event ID
+CREATE TABLE IF NOT EXISTS calendar_sync (
+  notion_page_id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL,
+  calendar_date TEXT NOT NULL
+);
+
+-- Processed Gmail message IDs (30-day retention, prevents reprocessing)
+CREATE TABLE IF NOT EXISTS processed_messages (
+  message_id TEXT PRIMARY KEY,
+  processed_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_processed_messages_at ON processed_messages(processed_at);

--- a/cf-worker/package-lock.json
+++ b/cf-worker/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.8.5",
         "@cloudflare/workers-types": "^4.20250422.0",
+        "dotenv-cli": "^8.0.0",
         "typescript": "^5.8.3",
         "vitest": "^3.1.2",
         "wrangler": "^4.0.0"
@@ -2445,6 +2446,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2496,6 +2512,45 @@
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-8.0.0.tgz",
+      "integrity": "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -2643,6 +2698,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2727,6 +2789,16 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2759,6 +2831,16 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2929,6 +3011,29 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -3288,6 +3393,22 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {

--- a/cf-worker/package-lock.json
+++ b/cf-worker/package-lock.json
@@ -1,0 +1,4522 @@
+{
+  "name": "ambient-agent-cf",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ambient-agent-cf",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.8.5",
+        "@cloudflare/workers-types": "^4.20250422.0",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.2",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.8.71",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.8.71.tgz",
+      "integrity": "sha512-keu2HCLQfRNwbmLBCDXJgCFpANTaYnQpE01fBOo4CNwiWHUT7SZGN7w64RKiSWRHyYppStXBuE5Ng7F42+flpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^5.3.2",
+        "miniflare": "4.20250906.0",
+        "semver": "^7.7.1",
+        "wrangler": "4.35.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
+      "integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.3.tgz",
+      "integrity": "sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.21",
+        "workerd": "^1.20250828.1"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.4",
+        "@esbuild/android-arm": "0.25.4",
+        "@esbuild/android-arm64": "0.25.4",
+        "@esbuild/android-x64": "0.25.4",
+        "@esbuild/darwin-arm64": "0.25.4",
+        "@esbuild/darwin-x64": "0.25.4",
+        "@esbuild/freebsd-arm64": "0.25.4",
+        "@esbuild/freebsd-x64": "0.25.4",
+        "@esbuild/linux-arm": "0.25.4",
+        "@esbuild/linux-arm64": "0.25.4",
+        "@esbuild/linux-ia32": "0.25.4",
+        "@esbuild/linux-loong64": "0.25.4",
+        "@esbuild/linux-mips64el": "0.25.4",
+        "@esbuild/linux-ppc64": "0.25.4",
+        "@esbuild/linux-riscv64": "0.25.4",
+        "@esbuild/linux-s390x": "0.25.4",
+        "@esbuild/linux-x64": "0.25.4",
+        "@esbuild/netbsd-arm64": "0.25.4",
+        "@esbuild/netbsd-x64": "0.25.4",
+        "@esbuild/openbsd-arm64": "0.25.4",
+        "@esbuild/openbsd-x64": "0.25.4",
+        "@esbuild/sunos-x64": "0.25.4",
+        "@esbuild/win32-arm64": "0.25.4",
+        "@esbuild/win32-ia32": "0.25.4",
+        "@esbuild/win32-x64": "0.25.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "version": "2.0.0-rc.21",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
+      "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.7",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.35.0.tgz",
+      "integrity": "sha512-HbyXtbrh4Fi3mU8ussY85tVdQ74qpVS1vctUgaPc+bPrXBTqfDLkZ6VRtHAVF/eBhz4SFmhJtCQpN1caY2Ak8A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.0",
+        "@cloudflare/unenv-preset": "2.7.3",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.25.4",
+        "miniflare": "4.20250906.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.21",
+        "workerd": "1.20250906.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250906.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250906.0.tgz",
+      "integrity": "sha512-E+X/YYH9BmX0ew2j/mAWFif2z05NMNuhCTlNYEGLkqMe99K15UewBqajL9pMcMUKxylnlrEoK3VNxl33DkbnPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250906.0.tgz",
+      "integrity": "sha512-X5apsZ1SFW4FYTM19ISHf8005FJMPfrcf4U5rO0tdj+TeJgQgXuZ57IG0WeW7SpLVeBo8hM6WC8CovZh41AfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250906.0.tgz",
+      "integrity": "sha512-rlKzWgsLnlQ5Nt9W69YBJKcmTmZbOGu0edUsenXPmc6wzULUxoQpi7ZE9k3TfTonJx4WoQsQlzCUamRYFsX+0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250906.0.tgz",
+      "integrity": "sha512-DdedhiQ+SeLzpg7BpcLrIPEZ33QKioJQ1wvL4X7nuLzEB9rWzS37NNNahQzc1+44rhG4fyiHbXBPOeox4B9XVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250906.0.tgz",
+      "integrity": "sha512-Q8Qjfs8jGVILnZL6vUpQ90q/8MTCYaGR3d1LGxZMBqte8Vr7xF3KFHPEy7tFs0j0mMjnqCYzlofmPNY+9ZaDRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260424.1.tgz",
+      "integrity": "sha512-0DLJ9yEk1KKzPbqop80Gw/P1wkKKzawmipULiJWdBXIBCoMvE0OVWms3IrL/Q/G7tfmPop9yF4XlZ69k9JLYng==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20250906.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250906.0.tgz",
+      "integrity": "sha512-T/RWn1sa0ien80s6NjU+Un/tj12gR6wqScZoiLeMJDD4/fK0UXfnbWXJDubnUED8Xjm7RPQ5ESYdE+mhPmMtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "sharp": "^0.33.5",
+        "stoppable": "1.1.0",
+        "undici": "^7.10.0",
+        "workerd": "1.20250906.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250906.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250906.0.tgz",
+      "integrity": "sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250906.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250906.0",
+        "@cloudflare/workerd-linux-64": "1.20250906.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250906.0",
+        "@cloudflare/workerd-windows-64": "1.20250906.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.85.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.85.0.tgz",
+      "integrity": "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260424.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260424.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260424.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260424.1.tgz",
+      "integrity": "sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260424.1.tgz",
+      "integrity": "sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260424.1.tgz",
+      "integrity": "sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "4.20260424.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260424.0.tgz",
+      "integrity": "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260424.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260424.1.tgz",
+      "integrity": "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260424.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260424.1",
+        "@cloudflare/workerd-linux-64": "1.20260424.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260424.1",
+        "@cloudflare/workerd-windows-64": "1.20260424.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cf-worker/package.json
+++ b/cf-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ambient-agent-cf",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.8.5",
+    "@cloudflare/workers-types": "^4.20250422.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/cf-worker/package.json
+++ b/cf-worker/package.json
@@ -3,16 +3,22 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "dev": "dotenv -e .env.local -- wrangler dev",
+    "deploy": "dotenv -e .env.local -- wrangler deploy",
+    "d1": "dotenv -e .env.local -- wrangler d1",
+    "kv": "dotenv -e .env.local -- wrangler kv:namespace",
+    "secret": "dotenv -e .env.local -- wrangler secret",
+    "whoami": "dotenv -e .env.local -- wrangler whoami",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "cf-typegen": "wrangler types"
+    "secrets:push": "dotenv -e .env.local -- node scripts/push-secrets.mjs",
+    "cf-typegen": "dotenv -e .env.local -- wrangler types"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.5",
     "@cloudflare/workers-types": "^4.20250422.0",
+    "dotenv-cli": "^8.0.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.2",
     "wrangler": "^4.0.0"

--- a/cf-worker/package.json
+++ b/cf-worker/package.json
@@ -6,7 +6,7 @@
     "dev": "dotenv -e .env.local -- wrangler dev",
     "deploy": "dotenv -e .env.local -- wrangler deploy",
     "d1": "dotenv -e .env.local -- wrangler d1",
-    "kv": "dotenv -e .env.local -- wrangler kv:namespace",
+    "kv": "dotenv -e .env.local -- wrangler kv",
     "secret": "dotenv -e .env.local -- wrangler secret",
     "whoami": "dotenv -e .env.local -- wrangler whoami",
     "test": "vitest run",

--- a/cf-worker/scripts/migrate-data.ts
+++ b/cf-worker/scripts/migrate-data.ts
@@ -1,0 +1,115 @@
+/**
+ * データ移行スクリプト
+ * 使い方: npx tsx scripts/migrate-data.ts
+ *
+ * 既存の data/*.json を Cloudflare D1 / KV へ移行する。
+ * 実行前に wrangler.toml の database_id と kv_namespace id を設定すること。
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const DATA_DIR = "../data";
+
+function wrangler(args: string): string {
+  return execSync(`wrangler ${args}`, { encoding: "utf-8", cwd: "../" });
+}
+
+function migrateThreadMap(): void {
+  const path = `${DATA_DIR}/gmail_thread_map.json`;
+  if (!existsSync(path)) {
+    console.log("gmail_thread_map.json not found, skipping");
+    return;
+  }
+  const data: Record<string, string> = JSON.parse(readFileSync(path, "utf-8"));
+  const entries = Object.entries(data);
+  if (!entries.length) return;
+
+  console.log(`Migrating ${entries.length} thread map entries...`);
+  for (const [threadId, pageId] of entries) {
+    const sql = `INSERT OR REPLACE INTO gmail_thread_map (thread_id, notion_page_id) VALUES ('${threadId}', '${pageId}');`;
+    wrangler(`d1 execute ambient-agent-db --command "${sql}"`);
+  }
+  console.log("✓ gmail_thread_map migrated");
+}
+
+function migrateCalendarSync(): void {
+  const path = `${DATA_DIR}/calendar_sync.json`;
+  if (!existsSync(path)) {
+    console.log("calendar_sync.json not found, skipping");
+    return;
+  }
+  const data: Record<string, { event_id: string; calendar_date: string }> = JSON.parse(
+    readFileSync(path, "utf-8"),
+  );
+  const entries = Object.entries(data);
+  if (!entries.length) return;
+
+  console.log(`Migrating ${entries.length} calendar sync entries...`);
+  for (const [pageId, { event_id, calendar_date }] of entries) {
+    const sql = `INSERT OR REPLACE INTO calendar_sync (notion_page_id, event_id, calendar_date) VALUES ('${pageId}', '${event_id}', '${calendar_date}');`;
+    wrangler(`d1 execute ambient-agent-db --command "${sql}"`);
+  }
+  console.log("✓ calendar_sync migrated");
+}
+
+function migrateSenderMap(): void {
+  const path = `${DATA_DIR}/task_sender_map.json`;
+  if (!existsSync(path)) {
+    console.log("task_sender_map.json not found, skipping");
+    return;
+  }
+  const data: Record<string, string> = JSON.parse(readFileSync(path, "utf-8"));
+  const entries = Object.entries(data);
+  if (!entries.length) return;
+
+  console.log(`Migrating ${entries.length} sender map entries...`);
+  for (const [pageId, email] of entries) {
+    const sql = `INSERT OR REPLACE INTO task_sender_map (notion_page_id, sender_email) VALUES ('${pageId}', '${email}');`;
+    wrangler(`d1 execute ambient-agent-db --command "${sql}"`);
+  }
+  console.log("✓ task_sender_map migrated");
+}
+
+function migrateNoTaskSenders(): void {
+  const path = `${DATA_DIR}/no_task_senders.txt`;
+  if (!existsSync(path)) {
+    console.log("no_task_senders.txt not found, skipping");
+    return;
+  }
+  const content = readFileSync(path, "utf-8").trim();
+  if (!content) return;
+
+  wrangler(`kv:key put --binding=AGENT_KV "no_task_senders" "${content.replace(/"/g, '\\"')}"`);
+  console.log("✓ no_task_senders migrated to KV");
+}
+
+function extractRefreshToken(): void {
+  const path = `${DATA_DIR}/token.json`;
+  if (!existsSync(path)) {
+    console.log("token.json not found. You need to run Google OAuth manually.");
+    return;
+  }
+  const token = JSON.parse(readFileSync(path, "utf-8"));
+  if (token.refresh_token) {
+    console.log("\n=== Google Refresh Token ===");
+    console.log("Run: wrangler secret put GOOGLE_REFRESH_TOKEN");
+    console.log("Then paste:", token.refresh_token);
+  } else {
+    console.log("No refresh_token found in token.json");
+  }
+}
+
+// Main
+console.log("=== ambient-agent データ移行 ===\n");
+migrateThreadMap();
+migrateCalendarSync();
+migrateSenderMap();
+migrateNoTaskSenders();
+extractRefreshToken();
+console.log("\n✓ 移行完了");
+console.log("\n次のステップ:");
+console.log("1. 上記の refresh_token を wrangler secret put GOOGLE_REFRESH_TOKEN で登録");
+console.log("2. その他の secrets を登録 (wrangler secret put ANTHROPIC_API_KEY 等)");
+console.log("3. Telegram Webhook を設定:");
+console.log("   curl -X POST https://api.telegram.org/bot{TOKEN}/setWebhook -d 'url=https://ambient-agent.YOUR_SUBDOMAIN.workers.dev/webhook'");

--- a/cf-worker/scripts/push-secrets.mjs
+++ b/cf-worker/scripts/push-secrets.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Worker Secrets を .env.local から一括登録する
+// 使い方: npm run secrets:push
+
+import { execSync } from "node:child_process";
+
+const SECRET_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "NOTION_TOKEN",
+  "NOTION_TASKS_DB_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "TELEGRAM_CHAT_ID",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "GOOGLE_REFRESH_TOKEN",
+];
+
+let ok = 0;
+let skipped = 0;
+let failed = 0;
+
+for (const key of SECRET_KEYS) {
+  const value = process.env[key];
+  if (!value) {
+    console.warn(`  SKIP  ${key} (空なのでスキップ)`);
+    skipped++;
+    continue;
+  }
+  try {
+    execSync(`wrangler secret put ${key}`, {
+      input: value,
+      stdio: ["pipe", "inherit", "inherit"],
+    });
+    console.log(`  OK    ${key}`);
+    ok++;
+  } catch {
+    console.error(`  FAIL  ${key}`);
+    failed++;
+  }
+}
+
+console.log(`\n登録: ${ok}件 / スキップ: ${skipped}件 / 失敗: ${failed}件`);
+if (failed > 0) process.exit(1);

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -1,0 +1,163 @@
+import type { Env, ExtractedTask, EmailAnalysis } from "../types.js";
+import { recordUsage } from "../storage/kv.js";
+
+const MODEL = "claude-haiku-4-5-20251001";
+const API_URL = "https://api.anthropic.com/v1/messages";
+
+const EXTRACT_TASKS_PROMPT = `あなたはメールからタスクを抽出するアシスタントです。
+
+以下のメールを読み、アクションが必要な項目を JSON 配列で返してください。
+タスクが存在しない場合は空配列 \`[]\` を返してください。
+
+## 出力フォーマット（JSON のみ、説明文不要）
+
+\`\`\`json
+[
+  {
+    "title": "タスクのタイトル（簡潔に）",
+    "due": "YYYY-MM-DD または YYYY-MM-DDTHH:MM または null（時刻が明示されていれば時刻付きで返す）",
+    "priority": "high | medium | low",
+    "source": "Gmail"
+  }
+]
+\`\`\`
+
+## 判断基準
+- 返信・確認・提出・対応などのアクション動詞を含む文をタスクとして抽出する
+- 期日が明示されていればそれを due に設定する（不明な場合は null）
+- 緊急・至急・本日中 → high、それ以外は medium を基本とする
+- 広告・通知・ニュースレターからはタスクを抽出しない`;
+
+const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタントです。
+
+以下のメールを読み、要約とアクションが必要なタスクを JSON で返してください。
+
+## 出力フォーマット（JSON のみ、説明文不要）
+
+\`\`\`json
+{
+  "summary": "メールの内容を1〜2文で要約（日本語）",
+  "tasks": [
+    {
+      "title": "タスクのタイトル（簡潔に）",
+      "due": "YYYY-MM-DD または YYYY-MM-DDTHH:MM または null",
+      "priority": "high | medium | low",
+      "source": "Gmail"
+    }
+  ]
+}
+\`\`\`
+
+## 判断基準
+- summary: 誰から何の用件か、重要ポイントを1〜2文で
+- tasks: 返信・確認・提出・対応などのアクション動詞を含む文をタスクとして抽出する
+- 期日が明示されていればそれを due に設定する（不明な場合は null）
+- 緊急・至急・本日中 → high、それ以外は medium を基本とする
+- 広告・通知・ニュースレターからはタスクを抽出せず tasks は []`;
+
+interface AnthropicResponse {
+  content: Array<{ type: string; text: string }>;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+async function callClaude(
+  env: Env,
+  job: string,
+  system: string,
+  userContent: string | unknown[],
+  maxTokens = 1024,
+): Promise<string> {
+  const resp = await fetch(API_URL, {
+    method: "POST",
+    headers: {
+      "x-api-key": env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: "user", content: userContent }],
+    }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Anthropic API failed: ${resp.status} ${body}`);
+  }
+
+  const data = await resp.json<AnthropicResponse>();
+  await recordUsage(env, job, data.usage.input_tokens, data.usage.output_tokens);
+  return data.content[0]?.text ?? "";
+}
+
+function extractJsonList(text: string): ExtractedTask[] {
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) return [];
+  try {
+    return JSON.parse(match[0]) as ExtractedTask[];
+  } catch {
+    return [];
+  }
+}
+
+export async function extractTasksFromText(env: Env, label: string, subject: string, body: string): Promise<ExtractedTask[]> {
+  const text = await callClaude(env, label, EXTRACT_TASKS_PROMPT, `件名: ${subject}\n\n本文:\n${body}`);
+  return extractJsonList(text);
+}
+
+export async function analyzeEmail(env: Env, subject: string, body: string): Promise<EmailAnalysis> {
+  const text = await callClaude(env, "analyze_email", ANALYZE_EMAIL_PROMPT, `件名: ${subject}\n\n本文:\n${body.slice(0, 3000)}`);
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return { summary: text.trim(), tasks: [] };
+  try {
+    const result = JSON.parse(match[0]) as EmailAnalysis;
+    result.tasks ??= [];
+    result.summary ??= "";
+    return result;
+  } catch {
+    return { summary: text.trim(), tasks: [] };
+  }
+}
+
+export async function extractTasksFromUrlContent(env: Env, url: string, content: string): Promise<ExtractedTask[]> {
+  const text = await callClaude(env, "extract_tasks_url", EXTRACT_TASKS_PROMPT, `件名: ${url}\n\n本文:\n${content.slice(0, 3000)}`);
+  return extractJsonList(text);
+}
+
+export async function extractTasksFromImage(env: Env, imageData: ArrayBuffer, mediaType: string): Promise<ExtractedTask[]> {
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(imageData)));
+  const userContent = [
+    { type: "image", source: { type: "base64", media_type: mediaType, data: b64 } },
+    { type: "text", text: "この画像からアクションが必要なタスクを抽出してください。" },
+  ];
+  const text = await callClaude(env, "extract_tasks_image", EXTRACT_TASKS_PROMPT, userContent);
+  return extractJsonList(text);
+}
+
+export async function summarizeDay(
+  env: Env,
+  calendarEvents: Array<{ summary: string; start: string }>,
+  tasks: Array<{ title: string; priority: string; due: string | null }>,
+  overdueTasks: Array<{ title: string; priority: string; due: string | null }>,
+): Promise<string> {
+  const eventsText = calendarEvents.map((e) => `- ${e.start} ${e.summary}`).join("\n") || "（なし）";
+  const tasksText = tasks.map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"})`).join("\n") || "（なし）";
+  const overdueText = overdueTasks.map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? ""})`).join("\n") || "（なし）";
+
+  const prompt = `今日の予定とタスクをもとに、簡潔な日次ブリーフィングを日本語で作成してください。
+
+## 今日の予定
+${eventsText}
+
+## 未完了タスク
+${tasksText}
+
+## 期限切れタスク
+${overdueText}
+
+ブリーフィングは3〜5文程度にまとめてください。期限切れタスクがある場合は必ず言及してください。`;
+
+  return callClaude(env, "summarize_day", "", prompt, 512);
+}

--- a/cf-worker/src/clients/gcal-api.ts
+++ b/cf-worker/src/clients/gcal-api.ts
@@ -1,0 +1,83 @@
+import type { Env, CalendarEvent } from "../types.js";
+import { getAccessToken } from "./google-auth.js";
+
+const BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
+
+function authHeader(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function getTodaysEvents(env: Env): Promise<CalendarEvent[]> {
+  const token = await getAccessToken(env);
+
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 0);
+
+  const jstOffset = "+09:00";
+  const timeMin = start.toISOString().slice(0, 19) + jstOffset;
+  const timeMax = end.toISOString().slice(0, 19) + jstOffset;
+
+  const params = new URLSearchParams({
+    timeMin,
+    timeMax,
+    singleEvents: "true",
+    orderBy: "startTime",
+  });
+
+  const resp = await fetch(`${BASE}/events?${params}`, { headers: authHeader(token) });
+  if (!resp.ok) throw new Error(`Google Calendar list failed: ${resp.status}`);
+
+  const data = await resp.json<{
+    items: Array<{
+      summary?: string;
+      start: { dateTime?: string; date?: string };
+    }>;
+  }>();
+
+  return (data.items ?? []).map((e) => ({
+    summary: e.summary ?? "",
+    start: e.start.dateTime ?? e.start.date ?? "",
+  }));
+}
+
+export async function insertEvent(env: Env, title: string, due: string): Promise<string | null> {
+  const token = await getAccessToken(env);
+
+  let body: Record<string, unknown>;
+  if (due.includes("T")) {
+    const startDt = new Date(due);
+    const endDt = new Date(startDt.getTime() + 60 * 60 * 1000);
+    body = {
+      summary: title,
+      start: { dateTime: startDt.toISOString(), timeZone: "Asia/Tokyo" },
+      end: { dateTime: endDt.toISOString(), timeZone: "Asia/Tokyo" },
+    };
+  } else {
+    body = {
+      summary: title,
+      start: { date: due },
+      end: { date: due },
+    };
+  }
+
+  const resp = await fetch(`${BASE}/events`, {
+    method: "POST",
+    headers: { ...authHeader(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) return null;
+  const event = await resp.json<{ id: string }>();
+  return event.id ?? null;
+}
+
+export async function deleteEvent(env: Env, eventId: string): Promise<void> {
+  const token = await getAccessToken(env);
+  await fetch(`${BASE}/events/${eventId}`, {
+    method: "DELETE",
+    headers: authHeader(token),
+  });
+}

--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -1,0 +1,153 @@
+import type { Env } from "../types.js";
+import { getAccessToken } from "./google-auth.js";
+
+const BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
+const GMAIL_QUERY = "is:unread in:inbox -category:promotions";
+const MAX_MESSAGES_PER_RUN = 200;
+
+interface GmailMessage {
+  id: string;
+  threadId: string;
+  payload: GmailPayload;
+}
+
+interface GmailPayload {
+  headers: Array<{ name: string; value: string }>;
+  mimeType: string;
+  body?: { data?: string };
+  parts?: GmailPayload[];
+}
+
+function authHeader(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function parseHeaders(payload: GmailPayload): Record<string, string> {
+  return Object.fromEntries(payload.headers.map((h) => [h.name, h.value]));
+}
+
+function isCalendarInvite(payload: GmailPayload): boolean {
+  if (payload.mimeType.startsWith("text/calendar")) return true;
+  return (payload.parts ?? []).some(isCalendarInvite);
+}
+
+function extractBody(payload: GmailPayload): string {
+  if (payload.mimeType === "text/plain") {
+    const data = payload.body?.data ?? "";
+    try {
+      return atob(data.replace(/-/g, "+").replace(/_/g, "/"));
+    } catch {
+      return "";
+    }
+  }
+  for (const part of payload.parts ?? []) {
+    const result = extractBody(part);
+    if (result) return result;
+  }
+  return "";
+}
+
+function extractEmail(sender: string): string {
+  if (sender.includes("<") && sender.includes(">")) {
+    return sender.split("<")[1].replace(">", "").trim().toLowerCase();
+  }
+  return sender.trim().toLowerCase();
+}
+
+export async function listAllMessages(env: Env): Promise<Array<{ id: string; threadId: string }>> {
+  const token = await getAccessToken(env);
+  const messages: Array<{ id: string; threadId: string }> = [];
+  let pageToken: string | undefined;
+
+  while (messages.length < MAX_MESSAGES_PER_RUN) {
+    const batch = Math.min(100, MAX_MESSAGES_PER_RUN - messages.length);
+    const params = new URLSearchParams({ q: GMAIL_QUERY, maxResults: String(batch) });
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const resp = await fetch(`${BASE}/messages?${params}`, { headers: authHeader(token) });
+    if (!resp.ok) throw new Error(`Gmail list messages failed: ${resp.status}`);
+
+    const data = await resp.json<{
+      messages?: Array<{ id: string; threadId: string }>;
+      nextPageToken?: string;
+    }>();
+    messages.push(...(data.messages ?? []));
+    pageToken = data.nextPageToken;
+    if (!pageToken) break;
+  }
+
+  return messages;
+}
+
+export async function getMessage(env: Env, msgId: string): Promise<GmailMessage> {
+  const token = await getAccessToken(env);
+  const resp = await fetch(`${BASE}/messages/${msgId}?format=full`, {
+    headers: authHeader(token),
+  });
+  if (!resp.ok) throw new Error(`Gmail getMessage failed: ${resp.status}`);
+  return resp.json<GmailMessage>();
+}
+
+export function parseMessage(msg: GmailMessage): { subject: string; body: string; senderEmail: string; threadId: string; gmailUrl: string } {
+  const headers = parseHeaders(msg.payload);
+  const subject = headers["Subject"] ?? "(件名なし)";
+  const body = extractBody(msg.payload);
+  const senderEmail = extractEmail(headers["From"] ?? "");
+  const threadId = msg.threadId ?? "";
+
+  const messageIdHeader = headers["Message-ID"] ?? "";
+  const gmailUrl = messageIdHeader
+    ? `https://mail.google.com/mail/u/0/#search/rfc822msgid:${encodeURIComponent(messageIdHeader)}`
+    : `https://mail.google.com/mail/u/0/#all/${threadId}`;
+
+  return { subject, body, senderEmail, threadId, gmailUrl };
+}
+
+export { isCalendarInvite };
+
+export async function archiveMessage(env: Env, msgId: string): Promise<void> {
+  const token = await getAccessToken(env);
+  const resp = await fetch(`${BASE}/messages/${msgId}/modify`, {
+    method: "POST",
+    headers: { ...authHeader(token), "Content-Type": "application/json" },
+    body: JSON.stringify({ removeLabelIds: ["INBOX"] }),
+  });
+  if (!resp.ok) throw new Error(`Gmail archive failed: ${resp.status}`);
+}
+
+export async function addLabel(env: Env, msgId: string, labelId: string): Promise<void> {
+  const token = await getAccessToken(env);
+  await fetch(`${BASE}/messages/${msgId}/modify`, {
+    method: "POST",
+    headers: { ...authHeader(token), "Content-Type": "application/json" },
+    body: JSON.stringify({ addLabelIds: [labelId] }),
+  });
+}
+
+export async function getOrCreateLabel(env: Env, labelName: string): Promise<string | null> {
+  const cacheKey = `gmail:label:${labelName}`;
+  const cached = await env.AGENT_KV.get(cacheKey);
+  if (cached) return cached;
+
+  const token = await getAccessToken(env);
+  const listResp = await fetch(`${BASE}/labels`, { headers: authHeader(token) });
+  if (!listResp.ok) return null;
+
+  const data = await listResp.json<{ labels: Array<{ id: string; name: string }> }>();
+  const existing = data.labels.find((l) => l.name === labelName);
+  if (existing) {
+    await env.AGENT_KV.put(cacheKey, existing.id, { expirationTtl: 3600 });
+    return existing.id;
+  }
+
+  const createResp = await fetch(`${BASE}/labels`, {
+    method: "POST",
+    headers: { ...authHeader(token), "Content-Type": "application/json" },
+    body: JSON.stringify({ name: labelName }),
+  });
+  if (!createResp.ok) return null;
+
+  const newLabel = await createResp.json<{ id: string }>();
+  await env.AGENT_KV.put(cacheKey, newLabel.id, { expirationTtl: 3600 });
+  return newLabel.id;
+}

--- a/cf-worker/src/clients/google-auth.ts
+++ b/cf-worker/src/clients/google-auth.ts
@@ -1,0 +1,43 @@
+import type { Env } from "../types.js";
+
+const TOKEN_KV_KEY = "google:access_token";
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+export async function getAccessToken(env: Env): Promise<string> {
+  const cached = await env.AGENT_KV.get<TokenCache>(TOKEN_KV_KEY, "json");
+  if (cached && cached.expiresAt > Date.now() + 60_000) {
+    return cached.token;
+  }
+
+  const resp = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      refresh_token: env.GOOGLE_REFRESH_TOKEN,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Google OAuth refresh failed: ${resp.status} ${body}`);
+  }
+
+  const data = await resp.json<{ access_token: string; expires_in: number }>();
+  const cache: TokenCache = {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+
+  await env.AGENT_KV.put(TOKEN_KV_KEY, JSON.stringify(cache), {
+    expirationTtl: Math.max(data.expires_in - 120, 60),
+  });
+
+  return data.access_token;
+}

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -1,0 +1,273 @@
+import type { Env, Task, TaskInput, ExtractedTask } from "../types.js";
+
+const NOTION_API = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+const DATA_SOURCE_KV_KEY = "notion:data_source_id";
+
+const STATUS_PENDING = "未着手";
+const STATUS_IN_PROGRESS_GROUP = ["進行中", "確認中", "一時中断"];
+const STATUS_DONE = "完了";
+const STATUS_CANCELLED = "中止";
+
+function headers(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "Notion-Version": NOTION_VERSION,
+  };
+}
+
+async function getDataSourceId(env: Env): Promise<string | null> {
+  const cached = await env.AGENT_KV.get(DATA_SOURCE_KV_KEY);
+  if (cached) return cached;
+
+  const resp = await fetch(`${NOTION_API}/databases/${env.NOTION_TASKS_DB_ID}`, {
+    headers: headers(env.NOTION_TOKEN),
+  });
+  if (!resp.ok) return null;
+
+  const db = await resp.json<{ data_sources?: Array<{ id: string }> }>();
+  const sources = db.data_sources ?? [];
+  if (!sources.length) return null;
+
+  const id = sources[0].id;
+  await env.AGENT_KV.put(DATA_SOURCE_KV_KEY, id, { expirationTtl: 86400 });
+  return id;
+}
+
+async function queryDB(env: Env, filter: Record<string, unknown>): Promise<{ results: unknown[] }> {
+  const dsId = await getDataSourceId(env);
+  if (dsId) {
+    const resp = await fetch(`${NOTION_API}/data_sources/${dsId}/query`, {
+      method: "POST",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({ filter }),
+    });
+    if (resp.ok) return resp.json();
+  }
+
+  // fallback to databases.query
+  const resp = await fetch(`${NOTION_API}/databases/${env.NOTION_TASKS_DB_ID}/query`, {
+    method: "POST",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify({ filter }),
+  });
+  if (!resp.ok) throw new Error(`Notion query failed: ${resp.status}`);
+  return resp.json();
+}
+
+function parseTaskPage(page: Record<string, unknown>): Task {
+  const props = (page.properties ?? {}) as Record<string, unknown>;
+
+  const titleArr = ((props["タイトル"] as Record<string, unknown> | undefined)?.title as Array<{ text: { content: string } }> | undefined) ?? [];
+  const title = titleArr[0]?.text.content ?? "";
+
+  const dueObj = (props["Due"] as Record<string, unknown> | undefined)?.date as { start: string } | undefined;
+  const due = dueObj?.start ?? null;
+
+  const priorityObj = (props["Priority"] as Record<string, unknown> | undefined)?.select as { name: string } | undefined;
+  const priority = (priorityObj?.name ?? "medium") as Task["priority"];
+
+  const statusObj = (props["Status"] as Record<string, unknown> | undefined)?.status as { name: string } | undefined;
+  const status = statusObj?.name ?? STATUS_PENDING;
+
+  const lastEdited = typeof page.last_edited_time === "string" ? page.last_edited_time.slice(0, 10) : null;
+
+  return {
+    title,
+    due,
+    priority,
+    status,
+    lastEdited,
+    url: (page.url as string) ?? "",
+    pageId: (page.id as string) ?? "",
+  };
+}
+
+export async function addTask(env: Env, task: TaskInput, checklist?: string[]): Promise<string | null> {
+  const properties: Record<string, unknown> = {
+    "タイトル": { title: [{ text: { content: task.title } }] },
+    Status: { status: { name: STATUS_PENDING } },
+    Source: { rich_text: [{ text: { content: task.source ?? "Telegram" } }] },
+  };
+
+  if (task.sourceUrl) {
+    properties["SourceURL"] = { url: task.sourceUrl };
+  }
+
+  if (task.due) {
+    const notionDue = task.due.includes("T") ? task.due + "+09:00" : task.due;
+    properties["Due"] = { date: { start: notionDue } };
+  }
+
+  const priority = task.priority ?? "medium";
+  if (["high", "medium", "low"].includes(priority)) {
+    properties["Priority"] = { select: { name: priority } };
+  }
+
+  const body: Record<string, unknown> = {
+    parent: { database_id: env.NOTION_TASKS_DB_ID },
+    properties,
+  };
+
+  if (checklist?.length) {
+    body.children = checklist.map((item) => ({
+      object: "block",
+      type: "to_do",
+      to_do: {
+        rich_text: [{ type: "text", text: { content: item } }],
+        checked: false,
+      },
+    }));
+  }
+
+  const resp = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(`Notion addTask failed: ${resp.status}`);
+  const page = await resp.json<{ id: string }>();
+  return page.id ?? null;
+}
+
+export async function getOpenTasks(env: Env): Promise<Task[]> {
+  const statusFilters = [STATUS_PENDING, ...STATUS_IN_PROGRESS_GROUP].map((s) => ({
+    property: "Status",
+    status: { equals: s },
+  }));
+  const result = await queryDB(env, { or: statusFilters });
+  return (result.results as Record<string, unknown>[]).map(parseTaskPage);
+}
+
+export async function escalatePriorityTasks(env: Env): Promise<Task[]> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayStr = today.toISOString().slice(0, 10);
+  const deadline = new Date(today);
+  deadline.setDate(deadline.getDate() + 3);
+  const deadlineStr = deadline.toISOString().slice(0, 10);
+
+  const statusFilters = [STATUS_PENDING, ...STATUS_IN_PROGRESS_GROUP].map((s) => ({
+    property: "Status",
+    status: { equals: s },
+  }));
+
+  const result = await queryDB(env, {
+    and: [
+      { or: statusFilters },
+      { property: "Priority", select: { equals: "medium" } },
+      { property: "Due", date: { on_or_before: deadlineStr } },
+      { property: "Due", date: { on_or_after: todayStr } },
+    ],
+  });
+
+  const escalated: Task[] = [];
+  for (const page of result.results as Record<string, unknown>[]) {
+    const task = parseTaskPage(page);
+    await fetch(`${NOTION_API}/pages/${task.pageId}`, {
+      method: "PATCH",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({ properties: { Priority: { select: { name: "high" } } } }),
+    });
+    escalated.push(task);
+  }
+  return escalated;
+}
+
+export async function completeTask(env: Env, pageId: string): Promise<void> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    method: "PATCH",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify({ properties: { Status: { status: { name: STATUS_DONE } } } }),
+  });
+  if (!resp.ok) throw new Error(`completeTask failed: ${resp.status}`);
+}
+
+export async function cancelTask(env: Env, pageId: string): Promise<void> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    method: "PATCH",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify({ properties: { Status: { status: { name: STATUS_CANCELLED } } } }),
+  });
+  if (!resp.ok) throw new Error(`cancelTask failed: ${resp.status}`);
+}
+
+export async function getTaskStatus(env: Env, pageId: string): Promise<string | null> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    headers: headers(env.NOTION_TOKEN),
+  });
+  if (!resp.ok) return null;
+  const page = await resp.json<{ archived?: boolean; properties?: Record<string, unknown> }>();
+  if (page.archived) return null;
+  const statusObj = (page.properties?.["Status"] as Record<string, unknown> | undefined)?.status as { name: string } | undefined;
+  return statusObj?.name ?? null;
+}
+
+export async function updateTaskDue(env: Env, pageId: string, due: string): Promise<void> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    method: "PATCH",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify({ properties: { Due: { date: { start: due } } } }),
+  });
+  if (!resp.ok) throw new Error(`updateTaskDue failed: ${resp.status}`);
+}
+
+export async function updateTaskFromReply(
+  env: Env,
+  pageId: string,
+  checklist: string[],
+  priority: string,
+  due: string | null,
+): Promise<void> {
+  const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+  const pageResp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    headers: headers(env.NOTION_TOKEN),
+  });
+  if (!pageResp.ok) throw new Error(`updateTaskFromReply: page fetch failed: ${pageResp.status}`);
+  const page = await pageResp.json<{ properties: Record<string, unknown> }>();
+  const props = page.properties;
+
+  const currentPriority = ((props["Priority"] as Record<string, unknown> | undefined)?.select as { name: string } | undefined)?.name ?? "medium";
+  const currentDueObj = (props["Due"] as Record<string, unknown> | undefined)?.date as { start: string } | undefined;
+  const currentDue = currentDueObj?.start?.slice(0, 10) ?? null;
+
+  const updates: Record<string, unknown> = {};
+
+  if ((priorityOrder[priority] ?? 1) < (priorityOrder[currentPriority] ?? 1)) {
+    updates["Priority"] = { select: { name: priority } };
+  }
+
+  if (due) {
+    const dueDate = due.slice(0, 10);
+    if (!currentDue || dueDate < currentDue) {
+      updates["Due"] = { date: { start: dueDate } };
+    }
+  }
+
+  if (Object.keys(updates).length) {
+    await fetch(`${NOTION_API}/pages/${pageId}`, {
+      method: "PATCH",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({ properties: updates }),
+    });
+  }
+
+  if (checklist.length) {
+    await fetch(`${NOTION_API}/blocks/${pageId}/children`, {
+      method: "PATCH",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({
+        children: checklist.map((item) => ({
+          object: "block",
+          type: "to_do",
+          to_do: {
+            rich_text: [{ type: "text", text: { content: item } }],
+            checked: false,
+          },
+        })),
+      }),
+    });
+  }
+}

--- a/cf-worker/src/clients/telegram.ts
+++ b/cf-worker/src/clients/telegram.ts
@@ -1,0 +1,48 @@
+import type { Env } from "../types.js";
+
+const MAX_LENGTH = 4096;
+
+function apiUrl(token: string, method: string): string {
+  return `https://api.telegram.org/bot${token}/${method}`;
+}
+
+export async function sendMessage(env: Env, text: string): Promise<void> {
+  const url = apiUrl(env.TELEGRAM_BOT_TOKEN, "sendMessage");
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += MAX_LENGTH) {
+    chunks.push(text.slice(i, i + MAX_LENGTH));
+  }
+  for (const chunk of chunks) {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: env.TELEGRAM_CHAT_ID,
+        text: chunk,
+        parse_mode: "Markdown",
+      }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      throw new Error(`Telegram sendMessage failed: ${resp.status} ${body}`);
+    }
+  }
+}
+
+export async function getFileUrl(env: Env, fileId: string): Promise<string> {
+  const resp = await fetch(apiUrl(env.TELEGRAM_BOT_TOKEN, "getFile"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ file_id: fileId }),
+  });
+  if (!resp.ok) throw new Error(`getFile failed: ${resp.status}`);
+  const data = await resp.json<{ ok: boolean; result: { file_path: string } }>();
+  return `https://api.telegram.org/file/bot${env.TELEGRAM_BOT_TOKEN}/${data.result.file_path}`;
+}
+
+export function escapeMd(text: string): string {
+  for (const ch of ["\\", "*", "_", "`", "["]) {
+    text = text.replaceAll(ch, `\\${ch}`);
+  }
+  return text;
+}

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -1,0 +1,77 @@
+import type { Env } from "../types.js";
+import { getTodaysEvents } from "../clients/gcal-api.js";
+import { getOpenTasks } from "../clients/notion.js";
+import { summarizeDay } from "../clients/anthropic.js";
+import { sendMessage } from "../clients/telegram.js";
+import { getDailyUsage } from "../storage/kv.js";
+
+const PRICE_INPUT_PER_M = 0.8;
+const PRICE_OUTPUT_PER_M = 4.0;
+
+function calcCost(inputTokens: number, outputTokens: number): number {
+  return (inputTokens / 1_000_000) * PRICE_INPUT_PER_M + (outputTokens / 1_000_000) * PRICE_OUTPUT_PER_M;
+}
+
+function jstDateStr(): string {
+  return new Date().toLocaleDateString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).replace(/\//g, "-");
+}
+
+export async function sendDailyBriefing(env: Env): Promise<void> {
+  const [events, tasks] = await Promise.all([getTodaysEvents(env), getOpenTasks(env)]);
+
+  const todayStr = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }))
+    .toISOString()
+    .slice(0, 10);
+  const overdue = tasks.filter((t) => t.due && t.due.slice(0, 10) < todayStr);
+
+  const summary = await summarizeDay(env, events, tasks, overdue);
+  const dateStr = jstDateStr();
+  await sendMessage(env, `*📅 日次ブリーフィング ${dateStr}*\n\n${summary}`);
+}
+
+export async function sendCostReport(env: Env): Promise<void> {
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+  const entries = await getDailyUsage(env, yesterdayStr);
+
+  if (!entries.length) {
+    await sendMessage(env, `*💰 コストレポート ${yesterdayStr}*\n\nClaude API の呼び出しはありませんでした。`);
+    return;
+  }
+
+  let totalInput = 0;
+  let totalOutput = 0;
+  const byJob: Record<string, { input: number; output: number; calls: number }> = {};
+
+  for (const e of entries) {
+    totalInput += e.inputTokens;
+    totalOutput += e.outputTokens;
+    const j = (byJob[e.job] ??= { input: 0, output: 0, calls: 0 });
+    j.input += e.inputTokens;
+    j.output += e.outputTokens;
+    j.calls++;
+  }
+
+  const lines = [
+    `*💰 コストレポート ${yesterdayStr}*\n`,
+    `合計: $${calcCost(totalInput, totalOutput).toFixed(4)} USD`,
+    `API呼び出し: ${entries.length}回`,
+    `入力トークン: ${totalInput.toLocaleString()}`,
+    `出力トークン: ${totalOutput.toLocaleString()}`,
+    "",
+    "*ジョブ別内訳*",
+    ...Object.entries(byJob).map(
+      ([job, s]) => `• \`${job}\`: ${s.calls}回 / $${calcCost(s.input, s.output).toFixed(4)}`,
+    ),
+  ];
+
+  await sendMessage(env, lines.join("\n"));
+}

--- a/cf-worker/src/handlers/calendar.ts
+++ b/cf-worker/src/handlers/calendar.ts
@@ -1,0 +1,93 @@
+import type { Env } from "../types.js";
+import { getTodaysEvents, insertEvent, deleteEvent } from "../clients/gcal-api.js";
+import { getOpenTasks } from "../clients/notion.js";
+import { sendMessage } from "../clients/telegram.js";
+import { formatTaskList, fmtDue } from "./task-formatter.js";
+import { getCalendarSync, setCalendarSync, deleteCalendarSync, getAllCalendarSync } from "../storage/d1.js";
+
+export async function syncCalendar(env: Env): Promise<void> {
+  const tasks = await getOpenTasks(env);
+  const pendingIds = new Set(tasks.map((t) => t.pageId));
+  const store = await getAllCalendarSync(env);
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  // Remove events for completed/deleted tasks
+  for (const [pageId, { eventId }] of store) {
+    if (pendingIds.has(pageId)) continue;
+    try {
+      await deleteEvent(env, eventId);
+    } catch {
+      // ignore deletion errors (event may already be gone)
+    }
+    await deleteCalendarSync(env, pageId);
+  }
+
+  // Sync pending tasks
+  for (const task of tasks) {
+    if (!task.due) continue;
+    const dueDate = task.due.slice(0, 10);
+    const isOverdue = dueDate < today;
+    const targetDate = isOverdue ? today : dueDate;
+
+    const record = store.get(task.pageId);
+    if (record?.calendarDate === targetDate) continue;
+
+    if (record?.eventId) {
+      try {
+        await deleteEvent(env, record.eventId);
+      } catch {
+        // ignore
+      }
+    }
+
+    const eventDue = isOverdue ? targetDate : task.due;
+    const eventId = await insertEvent(env, task.title, eventDue);
+    if (eventId) {
+      await setCalendarSync(env, task.pageId, eventId, targetDate);
+    }
+  }
+}
+
+export async function deleteCalendarEventForTask(env: Env, pageId: string): Promise<void> {
+  const record = await getCalendarSync(env, pageId);
+  if (!record) return;
+  try {
+    await deleteEvent(env, record.eventId);
+  } catch {
+    // ignore
+  }
+  await deleteCalendarSync(env, pageId);
+}
+
+export async function sendDueSoonNotice(env: Env): Promise<void> {
+  const tasks = await getOpenTasks(env);
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const today = now.toISOString().slice(0, 10);
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+
+  const dueToday = tasks.filter((t) => t.due && t.due.slice(0, 10) === today);
+  const dueTomorrow = tasks.filter((t) => t.due && t.due.slice(0, 10) === tomorrowStr);
+
+  if (!dueToday.length && !dueTomorrow.length) return;
+
+  const sections: string[] = [];
+  if (dueToday.length) {
+    sections.push(`*📅 今日期限 (${dueToday.length}件)*\n` + dueToday.map((t) => `• ${t.title}`).join("\n"));
+  }
+  if (dueTomorrow.length) {
+    sections.push(`*📅 明日期限 (${dueTomorrow.length}件)*\n` + dueTomorrow.map((t) => `• ${t.title}`).join("\n"));
+  }
+  await sendMessage(env, "*⏰ 期限間近タスク*\n\n" + sections.join("\n\n"));
+}
+
+export async function sendTaskReminder(env: Env): Promise<void> {
+  const tasks = await getOpenTasks(env);
+  if (!tasks.length) return;
+  const body = formatTaskList(tasks);
+  await sendMessage(env, `*📋 未完了タスク (${tasks.length}件)*${body}`);
+}
+
+export { getTodaysEvents };

--- a/cf-worker/src/handlers/escalation.ts
+++ b/cf-worker/src/handlers/escalation.ts
@@ -1,0 +1,36 @@
+import type { Env } from "../types.js";
+import { getOpenTasks, escalatePriorityTasks } from "../clients/notion.js";
+import { sendMessage } from "../clients/telegram.js";
+import { fmtDue } from "./task-formatter.js";
+
+const STALE_DAYS = 14;
+
+export async function sendEscalationNotice(env: Env): Promise<void> {
+  const escalated = await escalatePriorityTasks(env);
+  if (!escalated.length) return;
+
+  const lines = escalated.map((t) => `• ${t.title}（期限: ${fmtDue(t.due)}）`);
+  await sendMessage(
+    env,
+    `*⬆️ 優先度を high に昇格しました (${escalated.length}件)*\n\n` + lines.join("\n"),
+  );
+}
+
+export async function sendStaleTasksNotice(env: Env): Promise<void> {
+  const tasks = await getOpenTasks(env);
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - STALE_DAYS);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+  const stale = tasks.filter((t) => t.lastEdited && t.lastEdited <= cutoffStr);
+  if (!stale.length) return;
+
+  const lines = stale.map((t) => `• ${t.title}（最終更新: ${t.lastEdited}）`);
+  await sendMessage(
+    env,
+    `*🕰 長期未更新タスク (${stale.length}件)*\n\n` +
+      lines.join("\n") +
+      "\n\n対応不要なら `/skip` で中止にしてください",
+  );
+}

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -1,0 +1,125 @@
+import type { Env } from "../types.js";
+import { listAllMessages, getMessage, parseMessage, isCalendarInvite, archiveMessage, addLabel, getOrCreateLabel } from "../clients/gmail-api.js";
+import { analyzeEmail } from "../clients/anthropic.js";
+import { addTask, updateTaskFromReply, getTaskStatus } from "../clients/notion.js";
+import { sendMessage, escapeMd } from "../clients/telegram.js";
+import {
+  getThreadMapEntry,
+  setThreadMapEntry,
+  getSenderForTask,
+  setSenderForTask,
+  deleteSenderMapEntry,
+  getAllSenderMap,
+  isProcessed,
+  markProcessed,
+  cleanOldProcessed,
+} from "../storage/d1.js";
+import { getNoTaskSenders, addNoTaskSender } from "../storage/kv.js";
+
+export async function checkGmail(env: Env): Promise<void> {
+  await cleanOldProcessed(env);
+
+  const messages = await listAllMessages(env);
+  if (!messages.length) return;
+
+  const noTaskSenders = await getNoTaskSenders(env);
+  const taskLabelName = env.GMAIL_TASK_LABEL ?? "タスク登録済み";
+  const taskLabelId = await getOrCreateLabel(env, taskLabelName);
+
+  const taskLines: string[] = [];
+  const archivedLines: string[] = [];
+
+  for (const meta of messages) {
+    if (await isProcessed(env, meta.id)) continue;
+
+    const msg = await getMessage(env, meta.id);
+
+    if (isCalendarInvite(msg.payload)) {
+      await archiveMessage(env, meta.id);
+      await markProcessed(env, meta.id);
+      continue;
+    }
+
+    const { subject, body, senderEmail, threadId, gmailUrl } = parseMessage(msg);
+
+    if (noTaskSenders.has(senderEmail)) {
+      await archiveMessage(env, meta.id);
+      await markProcessed(env, meta.id);
+      continue;
+    }
+
+    const analysis = await analyzeEmail(env, subject, body);
+    const { summary, tasks } = analysis;
+
+    if (tasks.length) {
+      const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+      const best = tasks.reduce((a, b) =>
+        (priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b,
+      );
+      const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
+      const checklist = tasks.map((t) => t.title);
+
+      const existingPageId = await getThreadMapEntry(env, threadId);
+
+      if (existingPageId) {
+        await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null);
+        if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+        taskLines.push(
+          `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+        );
+      } else {
+        const pageId = await addTask(
+          env,
+          { title: subject, due: dues[0] ?? null, priority: best.priority, source: "Gmail", sourceUrl: gmailUrl },
+          checklist,
+        );
+        if (pageId) {
+          if (threadId) await setThreadMapEntry(env, threadId, pageId);
+          await setSenderForTask(env, pageId, senderEmail);
+          if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+        }
+        taskLines.push(
+          `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+        );
+      }
+    } else {
+      archivedLines.push(`• *${escapeMd(subject)}*\n  ${escapeMd(summary)}`);
+    }
+
+    await archiveMessage(env, meta.id);
+    await markProcessed(env, meta.id);
+  }
+
+  if (!taskLines.length && !archivedLines.length) return;
+
+  const sections: string[] = [];
+  if (taskLines.length) sections.push("✅ *タスク登録*\n" + taskLines.join("\n"));
+  if (archivedLines.length) sections.push("📦 *アーカイブ済み*\n" + archivedLines.join("\n"));
+  await sendMessage(env, "*📧 メール処理完了*\n\n" + sections.join("\n\n"));
+}
+
+export async function learnFromCancelled(env: Env): Promise<void> {
+  const senderMap = await getAllSenderMap(env);
+  if (!senderMap.size) return;
+
+  const noTaskSenders = await getNoTaskSenders(env);
+  const learned: string[] = [];
+
+  for (const [pageId, senderEmail] of senderMap) {
+    const status = await getTaskStatus(env, pageId);
+    if (status === "中止") {
+      if (!noTaskSenders.has(senderEmail)) {
+        await addNoTaskSender(env, senderEmail);
+        noTaskSenders.add(senderEmail);
+        learned.push(senderEmail);
+      }
+      await deleteSenderMapEntry(env, pageId);
+    } else if (status === null || status === "完了") {
+      await deleteSenderMapEntry(env, pageId);
+    }
+  }
+
+  if (learned.length) {
+    await sendMessage(env, "📚 *送信者ブロックを学習しました*\n\n" + learned.map((s) => `• \`${s}\``).join("\n"));
+  }
+}

--- a/cf-worker/src/handlers/task-formatter.ts
+++ b/cf-worker/src/handlers/task-formatter.ts
@@ -1,0 +1,73 @@
+import type { Task } from "../types.js";
+
+const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+const PRIORITY_LABELS: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
+const STATUS_ORDER: Record<string, number> = { 未着手: 0, 進行中: 1, 確認中: 2, 一時中断: 3 };
+const STATUS_LABELS: Record<string, string> = {
+  未着手: "📋 未着手",
+  進行中: "▶️ 進行中",
+  確認中: "🔍 確認中",
+  一時中断: "⏸ 一時中断",
+};
+
+const WEEKDAYS_JP = ["月", "火", "水", "木", "金", "土", "日"];
+
+export function fmtDue(d: string | null): string {
+  if (!d) return "";
+  const due = new Date(d.slice(0, 10) + "T00:00:00+09:00");
+  if (isNaN(due.getTime())) return d;
+
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const delta = Math.round((due.getTime() - today.getTime()) / 86400000);
+
+  if (delta === 0) return "今日";
+  if (delta === 1) return "明日";
+  if (delta === 2) return "明後日";
+  if (delta >= 3 && delta < 14) {
+    const weekday = WEEKDAYS_JP[due.getDay() === 0 ? 6 : due.getDay() - 1];
+    const dueWeek = getWeekNumber(due);
+    const todayWeek = getWeekNumber(today);
+    const prefix = dueWeek === todayWeek ? "今週" : "来週";
+    return `${prefix}${weekday}曜`;
+  }
+
+  const y = due.getFullYear();
+  const m = String(due.getMonth() + 1).padStart(2, "0");
+  const day = String(due.getDate()).padStart(2, "0");
+  return `${y}年${m}月${day}日`;
+}
+
+function getWeekNumber(d: Date): number {
+  const startOfYear = new Date(d.getFullYear(), 0, 1);
+  return Math.ceil(((d.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7);
+}
+
+export function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    const statusDiff = (STATUS_ORDER[a.status] ?? 0) - (STATUS_ORDER[b.status] ?? 0);
+    if (statusDiff !== 0) return statusDiff;
+    const priorityDiff = (PRIORITY_ORDER[a.priority] ?? 1) - (PRIORITY_ORDER[b.priority] ?? 1);
+    if (priorityDiff !== 0) return priorityDiff;
+    return (a.due ?? "9999") < (b.due ?? "9999") ? -1 : 1;
+  });
+}
+
+export function formatTaskList(tasks: Task[], numbered = false): string {
+  const sorted = sortTasks(tasks);
+  let currentStatus = "";
+  const lines: string[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const t = sorted[i];
+    if (t.status !== currentStatus) {
+      currentStatus = t.status;
+      lines.push(`\n*${STATUS_LABELS[t.status] ?? t.status}*`);
+    }
+    const due = t.due ? `（${fmtDue(t.due)}）` : "";
+    const icon = PRIORITY_LABELS[t.priority] ?? "";
+    const prefix = numbered ? `${i + 1}. ` : "• ";
+    lines.push(`${prefix}${icon} ${t.title}${due}`);
+  }
+  return lines.join("\n");
+}

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -1,0 +1,296 @@
+import type { Env } from "../types.js";
+import { sendMessage, getFileUrl } from "../clients/telegram.js";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue } from "../clients/notion.js";
+import { extractTasksFromText, extractTasksFromUrlContent, extractTasksFromImage } from "../clients/anthropic.js";
+import { getSenderForTask } from "../storage/d1.js";
+import { getTaskCache, setTaskCache, getNoTaskSenders, addNoTaskSender, removeNoTaskSender } from "../storage/kv.js";
+import { deleteCalendarEventForTask } from "./calendar.js";
+import { formatTaskList, sortTasks } from "./task-formatter.js";
+import { sendDailyBriefing } from "./briefing.js";
+
+const URL_PATTERN = /https?:\/\/\S+/;
+const OPERATING_START_HOUR = 8;
+const OPERATING_END_HOUR = 21;
+
+function getJstHour(): number {
+  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" })).getHours();
+}
+
+function extractTextFromHtml(html: string): string {
+  return html
+    .replace(/<(script|style|nav|footer|header)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, "\n")
+    .trim();
+}
+
+async function handleCommand(env: Env, text: string): Promise<void> {
+  const [rawCommand, ...rest] = text.trim().split(/\s+/);
+  const command = rawCommand.toLowerCase();
+  const arg = rest.join(" ").trim();
+
+  switch (command) {
+    case "/tasks": {
+      const tasks = await getOpenTasks(env);
+      if (!tasks.length) {
+        await sendMessage(env, "✅ 未着手のタスクはありません");
+        return;
+      }
+      const sorted = sortTasks(tasks);
+      await setTaskCache(env, sorted);
+      const body = formatTaskList(tasks, true);
+      await sendMessage(env, `*📋 タスク一覧 (${sorted.length}件)*${body}\n\n\`/done <番号>\` で完了にできます`);
+      return;
+    }
+
+    case "/done": {
+      if (!/^\d+$/.test(arg)) {
+        await sendMessage(env, "使い方: `/done 2`（番号は `/tasks` で確認）");
+        return;
+      }
+      const index = parseInt(arg, 10) - 1;
+      const tasks = await getTaskCache(env);
+      if (!tasks.length) {
+        await sendMessage(env, "先に `/tasks` でタスク一覧を取得してください");
+        return;
+      }
+      if (index < 0 || index >= tasks.length) {
+        await sendMessage(env, `番号が範囲外です（1〜${tasks.length}）`);
+        return;
+      }
+      const task = tasks[index];
+      await completeTask(env, task.pageId);
+      await deleteCalendarEventForTask(env, task.pageId);
+      await sendMessage(env, `✅ 完了にしました\n\n*${task.title}*`);
+      return;
+    }
+
+    case "/add": {
+      if (!arg) {
+        await sendMessage(env, "使い方: `/add 〇〇を確認する`");
+        return;
+      }
+      await addTask(env, { title: arg, source: "Telegram", priority: "medium" });
+      await sendMessage(env, `✅ タスクを追加しました\n\n*${arg}*`);
+      return;
+    }
+
+    case "/skip": {
+      if (!/^\d+$/.test(arg)) {
+        await sendMessage(env, "使い方: `/skip 2`（番号は `/tasks` で確認）");
+        return;
+      }
+      const index = parseInt(arg, 10) - 1;
+      const tasks = await getTaskCache(env);
+      if (!tasks.length) {
+        await sendMessage(env, "先に `/tasks` でタスク一覧を取得してください");
+        return;
+      }
+      if (index < 0 || index >= tasks.length) {
+        await sendMessage(env, `番号が範囲外です（1〜${tasks.length}）`);
+        return;
+      }
+      const task = tasks[index];
+      await cancelTask(env, task.pageId);
+      await deleteCalendarEventForTask(env, task.pageId);
+      const sender = await getSenderForTask(env, task.pageId);
+      if (sender) {
+        await addNoTaskSender(env, sender);
+        await sendMessage(
+          env,
+          `🚫 タスクを中止にしました\n\n*${task.title}*\n\n\`${sender}\` からのメールは今後タスク登録しません`,
+        );
+      } else {
+        await sendMessage(env, `🚫 タスクを中止にしました\n\n*${task.title}*`);
+      }
+      return;
+    }
+
+    case "/due": {
+      const parts = arg.split(/\s+/, 2);
+      if (parts.length !== 2 || !/^\d+$/.test(parts[0])) {
+        await sendMessage(env, "使い方: `/due 2 2026-03-25`（番号は `/tasks` で確認）");
+        return;
+      }
+      const index = parseInt(parts[0], 10) - 1;
+      const dueStr = parts[1];
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dueStr) || isNaN(Date.parse(dueStr))) {
+        await sendMessage(env, "日付は `YYYY-MM-DD` 形式で指定してください");
+        return;
+      }
+      const tasks = await getTaskCache(env);
+      if (!tasks.length) {
+        await sendMessage(env, "先に `/tasks` でタスク一覧を取得してください");
+        return;
+      }
+      if (index < 0 || index >= tasks.length) {
+        await sendMessage(env, `番号が範囲外です（1〜${tasks.length}）`);
+        return;
+      }
+      const task = tasks[index];
+      await updateTaskDue(env, task.pageId, dueStr);
+      await sendMessage(env, `📅 期限を更新しました\n\n*${task.title}*\n→ ${dueStr}`);
+      return;
+    }
+
+    case "/briefing": {
+      await sendMessage(env, "⏳ ブリーフィングを生成中...");
+      await sendDailyBriefing(env);
+      return;
+    }
+
+    case "/blocklist": {
+      const senders = await getNoTaskSenders(env);
+      if (!senders.size) {
+        await sendMessage(env, "ブロック中の送信者はいません");
+      } else {
+        const lines = [...senders].sort().map((s) => `• \`${s}\``).join("\n");
+        await sendMessage(
+          env,
+          `*🚫 ブロック中の送信者 (${senders.size}件)*\n\n${lines}\n\n解除: \`/unblock メールアドレス\``,
+        );
+      }
+      return;
+    }
+
+    case "/unblock": {
+      if (!arg) {
+        await sendMessage(env, "使い方: `/unblock email@example.com`");
+        return;
+      }
+      if (await removeNoTaskSender(env, arg)) {
+        await sendMessage(env, `✅ \`${arg}\` のブロックを解除しました`);
+      } else {
+        await sendMessage(env, `\`${arg}\` はブロックリストにありません\n\n\`/blocklist\` で確認できます`);
+      }
+      return;
+    }
+
+    case "/help": {
+      await sendMessage(
+        env,
+        "*使えるコマンド*\n\n" +
+          "`/tasks` — タスク一覧\n" +
+          "`/done <番号>` — タスクを完了にする\n" +
+          "`/skip <番号>` — タスクを中止にし、送信者をブロック\n" +
+          "`/blocklist` — ブロック中の送信者一覧\n" +
+          "`/unblock <メール>` — 送信者のブロックを解除\n" +
+          "`/add <タスク名>` — タスクを追加\n" +
+          "`/due <番号> <日付>` — 期限を変更（例: `/due 3 2026-03-25`）\n" +
+          "`/briefing` — 今すぐブリーフィングを実行\n\n" +
+          "URL・テキスト・転送メッセージ・画像を送るとタスクを自動抽出します",
+      );
+      return;
+    }
+
+    default:
+      await sendMessage(
+        env,
+        "使えるコマンド:\n`/tasks` — タスク一覧\n`/done <番号>` — 完了にする\n`/add <タスク名>` — タスクを追加\n`/due <番号> <日付>` — 期限を変更\n`/briefing` — 今すぐブリーフィング",
+      );
+  }
+}
+
+async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<void> {
+  const photos = message.photo as Array<{ file_id: string; file_size: number }>;
+  const largest = photos.reduce((a, b) => (a.file_size > b.file_size ? a : b));
+
+  const fileUrl = await getFileUrl(env, largest.file_id);
+  const imgResp = await fetch(fileUrl);
+  if (!imgResp.ok) {
+    await sendMessage(env, `⚠️ 画像の取得に失敗しました`);
+    return;
+  }
+
+  const ext = fileUrl.split(".").pop()?.toLowerCase() ?? "jpg";
+  const mediaType = ({ jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif", webp: "image/webp" } as Record<string, string>)[ext] ?? "image/jpeg";
+
+  await sendMessage(env, "⏳ 画像からタスクを抽出中...");
+  const tasks = await extractTasksFromImage(env, await imgResp.arrayBuffer(), mediaType);
+  if (tasks.length) {
+    for (const task of tasks) {
+      await addTask(env, { ...task, source: "Telegram" });
+    }
+    await sendMessage(env, "✅ タスクを登録しました\n\n" + tasks.map((t) => `• ${t.title}`).join("\n"));
+  } else {
+    await sendMessage(env, "ℹ️ タスクは見つかりませんでした");
+  }
+}
+
+async function handleUrl(env: Env, url: string): Promise<void> {
+  let content = "";
+  let pageTitle = url;
+  try {
+    const resp = await fetch(url, { headers: { "User-Agent": "Mozilla/5.0" } });
+    if (resp.ok) {
+      const html = await resp.text();
+      const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+      pageTitle = titleMatch ? titleMatch[1].trim() : url;
+      content = extractTextFromHtml(html);
+    }
+  } catch {
+    // proceed with empty content
+  }
+
+  const tasks = await extractTasksFromUrlContent(env, url, content);
+  const finalTasks = tasks.length ? tasks : [{ title: `${pageTitle}を確認する`, due: null, priority: "medium" as const }];
+
+  for (const task of finalTasks) {
+    await addTask(env, { ...task, source: "URL", sourceUrl: url });
+  }
+  await sendMessage(env, "✅ タスクを登録しました\n\n" + finalTasks.map((t) => `• ${t.title}`).join("\n"));
+}
+
+export async function handleTelegramWebhook(env: Env, body: unknown): Promise<void> {
+  const update = body as { message?: Record<string, unknown> };
+  const message = update.message;
+  if (!message) return;
+
+  const chatId = String((message.chat as Record<string, unknown>)?.id ?? "");
+  if (chatId !== env.TELEGRAM_CHAT_ID) return;
+
+  const text = ((message.text as string) ?? "").trim();
+  const hasPhoto = Boolean(message.photo);
+
+  if (!text && !hasPhoto) return;
+
+  if (text.startsWith("/")) {
+    await handleCommand(env, text);
+    return;
+  }
+
+  const startHour = parseInt(env.OPERATING_START_HOUR ?? "8", 10);
+  const endHour = parseInt(env.OPERATING_END_HOUR ?? "21", 10);
+  const hour = getJstHour();
+  if (hour < startHour || hour >= endHour) {
+    await sendMessage(env, `🌙 夜間はタスク抽出を停止中です（${startHour}:00-${endHour}:00 に受け付けます）`);
+    return;
+  }
+
+  if (hasPhoto) {
+    await handlePhoto(env, message);
+    return;
+  }
+
+  const urlMatch = URL_PATTERN.exec(text);
+  if (urlMatch) {
+    await handleUrl(env, urlMatch[0]);
+    return;
+  }
+
+  const isForwarded = Boolean(message.forward_origin ?? message.forward_from ?? message.forward_from_chat);
+  const subject = isForwarded ? "転送メッセージ" : "Telegram メッセージ";
+  const tasks = await extractTasksFromText(env, "extract_tasks", subject, text);
+  if (tasks.length) {
+    for (const task of tasks) {
+      await addTask(env, { ...task, source: "Telegram" });
+    }
+    await sendMessage(env, "✅ タスクを登録しました\n\n" + tasks.map((t) => `• ${t.title}`).join("\n"));
+  } else {
+    await sendMessage(env, "ℹ️ タスクは見つかりませんでした");
+  }
+}

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -1,0 +1,59 @@
+import type { Env } from "./types.js";
+import { checkGmail, learnFromCancelled } from "./handlers/gmail.js";
+import { syncCalendar, sendDueSoonNotice, sendTaskReminder } from "./handlers/calendar.js";
+import { sendDailyBriefing, sendCostReport } from "./handlers/briefing.js";
+import { sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
+import { handleTelegramWebhook } from "./handlers/telegram.js";
+import { sendMessage } from "./clients/telegram.js";
+
+// Cron → job mapping (UTC cron expressions from wrangler.toml)
+const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
+  "50 22 * * *": learnFromCancelled,   // 07:50 JST
+  "55 22 * * *": checkGmail,           // 07:55 JST
+  "57 22 * * *": syncCalendar,         // 07:57 JST
+  "58 22 * * *": sendEscalationNotice, // 07:58 JST
+  "0 23 * * *": sendDailyBriefing,     // 08:00 JST
+  "5 23 * * *": sendCostReport,        // 08:05 JST
+  "10 23 * * *": sendDueSoonNotice,    // 08:10 JST
+  "0 4 * * *": sendTaskReminder,       // 13:00 JST
+  "0 0 * * 1": sendStaleTasksNotice,   // Mon 09:00 JST
+};
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/webhook" && req.method === "POST") {
+      try {
+        const body = await req.json();
+        await handleTelegramWebhook(env, body);
+      } catch (err) {
+        console.error("Webhook error:", err);
+      }
+      return new Response("OK");
+    }
+
+    return new Response("ambient-agent", { status: 200 });
+  },
+
+  async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
+    const job = CRON_JOBS[event.cron];
+    if (!job) {
+      console.warn("Unknown cron:", event.cron);
+      return;
+    }
+
+    try {
+      await job(env);
+    } catch (err) {
+      const jobName = Object.entries(CRON_JOBS).find(([, fn]) => fn === job)?.[0] ?? event.cron;
+      const msg = `⚠️ *Ambient Agent エラー*\nJob: \`${jobName}\`\n\`\`\`\n${err}\n\`\`\``;
+      console.error(msg, err);
+      try {
+        await sendMessage(env, msg);
+      } catch {
+        // ignore notification failure
+      }
+    }
+  },
+};

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -6,17 +6,25 @@ import { sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalatio
 import { handleTelegramWebhook } from "./handlers/telegram.js";
 import { sendMessage } from "./clients/telegram.js";
 
-// Cron → job mapping (UTC cron expressions from wrangler.toml)
+// 無料プランの Cron 上限（5個）に合わせて4つに統合
+async function morningPrep(env: Env): Promise<void> {
+  await learnFromCancelled(env);
+  await checkGmail(env);
+  await syncCalendar(env);
+  await sendEscalationNotice(env);
+}
+
+async function morningBriefing(env: Env): Promise<void> {
+  await sendDailyBriefing(env);
+  await sendCostReport(env);
+  await sendDueSoonNotice(env);
+}
+
 const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
-  "50 22 * * *": learnFromCancelled,   // 07:50 JST
-  "55 22 * * *": checkGmail,           // 07:55 JST
-  "57 22 * * *": syncCalendar,         // 07:57 JST
-  "58 22 * * *": sendEscalationNotice, // 07:58 JST
-  "0 23 * * *": sendDailyBriefing,     // 08:00 JST
-  "5 23 * * *": sendCostReport,        // 08:05 JST
-  "10 23 * * *": sendDueSoonNotice,    // 08:10 JST
+  "50 22 * * *": morningPrep,          // 07:50 JST: learn→gmail→calendar→escalation
+  "0 23 * * *": morningBriefing,       // 08:00 JST: briefing→cost→due_soon
   "0 4 * * *": sendTaskReminder,       // 13:00 JST
-  "0 0 * * 1": sendStaleTasksNotice,   // Mon 09:00 JST
+  "0 0 * * 1": sendStaleTasksNotice,   // 月 09:00 JST
 };
 
 export default {

--- a/cf-worker/src/storage/d1.ts
+++ b/cf-worker/src/storage/d1.ts
@@ -1,0 +1,111 @@
+import type { Env } from "../types.js";
+
+const PROCESSED_RETENTION_DAYS = 30;
+
+// gmail_thread_map
+export async function getThreadMapEntry(env: Env, threadId: string): Promise<string | null> {
+  const row = await env.AGENT_DB.prepare(
+    "SELECT notion_page_id FROM gmail_thread_map WHERE thread_id = ?",
+  )
+    .bind(threadId)
+    .first<{ notion_page_id: string }>();
+  return row?.notion_page_id ?? null;
+}
+
+export async function setThreadMapEntry(env: Env, threadId: string, pageId: string): Promise<void> {
+  await env.AGENT_DB.prepare(
+    "INSERT OR REPLACE INTO gmail_thread_map (thread_id, notion_page_id) VALUES (?, ?)",
+  )
+    .bind(threadId, pageId)
+    .run();
+}
+
+// task_sender_map
+export async function getSenderForTask(env: Env, pageId: string): Promise<string | null> {
+  const row = await env.AGENT_DB.prepare(
+    "SELECT sender_email FROM task_sender_map WHERE notion_page_id = ?",
+  )
+    .bind(pageId)
+    .first<{ sender_email: string }>();
+  return row?.sender_email ?? null;
+}
+
+export async function setSenderForTask(env: Env, pageId: string, email: string): Promise<void> {
+  await env.AGENT_DB.prepare(
+    "INSERT OR REPLACE INTO task_sender_map (notion_page_id, sender_email) VALUES (?, ?)",
+  )
+    .bind(pageId, email)
+    .run();
+}
+
+export async function deleteSenderMapEntry(env: Env, pageId: string): Promise<void> {
+  await env.AGENT_DB.prepare("DELETE FROM task_sender_map WHERE notion_page_id = ?")
+    .bind(pageId)
+    .run();
+}
+
+export async function getAllSenderMap(env: Env): Promise<Map<string, string>> {
+  const rows = await env.AGENT_DB.prepare(
+    "SELECT notion_page_id, sender_email FROM task_sender_map",
+  ).all<{ notion_page_id: string; sender_email: string }>();
+  return new Map(rows.results.map((r) => [r.notion_page_id, r.sender_email]));
+}
+
+// calendar_sync
+export async function getCalendarSync(env: Env, pageId: string): Promise<{ eventId: string; calendarDate: string } | null> {
+  const row = await env.AGENT_DB.prepare(
+    "SELECT event_id, calendar_date FROM calendar_sync WHERE notion_page_id = ?",
+  )
+    .bind(pageId)
+    .first<{ event_id: string; calendar_date: string }>();
+  if (!row) return null;
+  return { eventId: row.event_id, calendarDate: row.calendar_date };
+}
+
+export async function setCalendarSync(env: Env, pageId: string, eventId: string, calendarDate: string): Promise<void> {
+  await env.AGENT_DB.prepare(
+    "INSERT OR REPLACE INTO calendar_sync (notion_page_id, event_id, calendar_date) VALUES (?, ?, ?)",
+  )
+    .bind(pageId, eventId, calendarDate)
+    .run();
+}
+
+export async function deleteCalendarSync(env: Env, pageId: string): Promise<void> {
+  await env.AGENT_DB.prepare("DELETE FROM calendar_sync WHERE notion_page_id = ?")
+    .bind(pageId)
+    .run();
+}
+
+export async function getAllCalendarSync(env: Env): Promise<Map<string, { eventId: string; calendarDate: string }>> {
+  const rows = await env.AGENT_DB.prepare(
+    "SELECT notion_page_id, event_id, calendar_date FROM calendar_sync",
+  ).all<{ notion_page_id: string; event_id: string; calendar_date: string }>();
+  return new Map(rows.results.map((r) => [r.notion_page_id, { eventId: r.event_id, calendarDate: r.calendar_date }]));
+}
+
+// processed_messages
+export async function isProcessed(env: Env, messageId: string): Promise<boolean> {
+  const row = await env.AGENT_DB.prepare(
+    "SELECT 1 FROM processed_messages WHERE message_id = ?",
+  )
+    .bind(messageId)
+    .first<{ 1: number }>();
+  return row !== null;
+}
+
+export async function markProcessed(env: Env, messageId: string): Promise<void> {
+  await env.AGENT_DB.prepare(
+    "INSERT OR IGNORE INTO processed_messages (message_id) VALUES (?)",
+  )
+    .bind(messageId)
+    .run();
+}
+
+export async function cleanOldProcessed(env: Env): Promise<void> {
+  const cutoff = Math.floor(Date.now() / 1000) - PROCESSED_RETENTION_DAYS * 86400;
+  await env.AGENT_DB.prepare(
+    "DELETE FROM processed_messages WHERE processed_at < ?",
+  )
+    .bind(cutoff)
+    .run();
+}

--- a/cf-worker/src/storage/kv.ts
+++ b/cf-worker/src/storage/kv.ts
@@ -1,0 +1,59 @@
+import type { Env, Task, UsageEntry } from "../types.js";
+
+// Telegram
+export async function getTelegramOffset(env: Env): Promise<number> {
+  const val = await env.AGENT_KV.get("telegram:offset");
+  return val ? parseInt(val, 10) : 0;
+}
+
+export async function setTelegramOffset(env: Env, offset: number): Promise<void> {
+  await env.AGENT_KV.put("telegram:offset", String(offset));
+}
+
+export async function getTaskCache(env: Env): Promise<Task[]> {
+  const val = await env.AGENT_KV.get<Task[]>("telegram:task_cache", "json");
+  return val ?? [];
+}
+
+export async function setTaskCache(env: Env, tasks: Task[]): Promise<void> {
+  await env.AGENT_KV.put("telegram:task_cache", JSON.stringify(tasks));
+}
+
+// No-task senders blocklist
+export async function getNoTaskSenders(env: Env): Promise<Set<string>> {
+  const val = await env.AGENT_KV.get("no_task_senders");
+  if (!val) return new Set();
+  return new Set(
+    val
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+export async function addNoTaskSender(env: Env, email: string): Promise<void> {
+  const senders = await getNoTaskSenders(env);
+  senders.add(email.toLowerCase());
+  await env.AGENT_KV.put("no_task_senders", [...senders].sort().join("\n"));
+}
+
+export async function removeNoTaskSender(env: Env, email: string): Promise<boolean> {
+  const senders = await getNoTaskSenders(env);
+  if (!senders.has(email.toLowerCase())) return false;
+  senders.delete(email.toLowerCase());
+  await env.AGENT_KV.put("no_task_senders", [...senders].sort().join("\n"));
+  return true;
+}
+
+// Usage tracking
+export async function recordUsage(env: Env, job: string, inputTokens: number, outputTokens: number): Promise<void> {
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const key = `usage:${dateStr}`;
+  const existing = (await env.AGENT_KV.get<UsageEntry[]>(key, "json")) ?? [];
+  existing.push({ date: dateStr, job, inputTokens, outputTokens });
+  await env.AGENT_KV.put(key, JSON.stringify(existing), { expirationTtl: 30 * 86400 });
+}
+
+export async function getDailyUsage(env: Env, dateStr: string): Promise<UsageEntry[]> {
+  return (await env.AGENT_KV.get<UsageEntry[]>(`usage:${dateStr}`, "json")) ?? [];
+}

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -1,0 +1,59 @@
+export interface Env {
+  AGENT_KV: KVNamespace;
+  AGENT_DB: D1Database;
+  ANTHROPIC_API_KEY: string;
+  NOTION_TOKEN: string;
+  NOTION_TASKS_DB_ID: string;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_CHAT_ID: string;
+  GOOGLE_CLIENT_ID: string;
+  GOOGLE_CLIENT_SECRET: string;
+  GOOGLE_REFRESH_TOKEN: string;
+  OPERATING_START_HOUR?: string;
+  OPERATING_END_HOUR?: string;
+  DAILY_BRIEFING_HOUR?: string;
+  TASK_REMINDER_HOURS?: string;
+  COST_REPORT_HOUR?: string;
+  GMAIL_TASK_LABEL?: string;
+}
+
+export interface Task {
+  title: string;
+  due: string | null;
+  priority: "high" | "medium" | "low";
+  status: string;
+  lastEdited: string | null;
+  url: string;
+  pageId: string;
+}
+
+export interface TaskInput {
+  title: string;
+  due?: string | null;
+  priority?: "high" | "medium" | "low";
+  source?: string;
+  sourceUrl?: string;
+}
+
+export interface ExtractedTask {
+  title: string;
+  due: string | null;
+  priority: "high" | "medium" | "low";
+}
+
+export interface EmailAnalysis {
+  summary: string;
+  tasks: ExtractedTask[];
+}
+
+export interface UsageEntry {
+  date: string;
+  job: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface CalendarEvent {
+  summary: string;
+  start: string;
+}

--- a/cf-worker/test/fixtures/claude-responses.json
+++ b/cf-worker/test/fixtures/claude-responses.json
@@ -1,0 +1,38 @@
+{
+  "extractTasksResponse": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"title\": \"プロジェクト資料を確認する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"source\": \"Gmail\"}]"
+      }
+    ],
+    "usage": { "input_tokens": 150, "output_tokens": 50 }
+  },
+  "analyzeEmailResponse": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"summary\": \"田中さんからプロジェクトの進捗確認依頼。期限は4月30日。\", \"tasks\": [{\"title\": \"プロジェクト進捗を報告する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"source\": \"Gmail\"}]}"
+      }
+    ],
+    "usage": { "input_tokens": 200, "output_tokens": 80 }
+  },
+  "analyzeEmailNoTasksResponse": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"summary\": \"ニュースレターの配信通知。アクション不要。\", \"tasks\": []}"
+      }
+    ],
+    "usage": { "input_tokens": 100, "output_tokens": 30 }
+  },
+  "summarizeDayResponse": {
+    "content": [
+      {
+        "type": "text",
+        "text": "今日は3件のタスクがあります。期限切れタスクが1件あるため早急に対応が必要です。午後の会議に向けて資料準備を優先してください。"
+      }
+    ],
+    "usage": { "input_tokens": 300, "output_tokens": 60 }
+  }
+}

--- a/cf-worker/test/fixtures/gmail-messages.json
+++ b/cf-worker/test/fixtures/gmail-messages.json
@@ -1,0 +1,56 @@
+{
+  "listResponse": {
+    "messages": [
+      { "id": "msg-001", "threadId": "thread-001" },
+      { "id": "msg-002", "threadId": "thread-002" }
+    ]
+  },
+  "newEmail": {
+    "id": "msg-001",
+    "threadId": "thread-001",
+    "payload": {
+      "headers": [
+        { "name": "Subject", "value": "プロジェクトの進捗確認をお願いします" },
+        { "name": "From", "value": "tanaka@example.com" },
+        { "name": "Message-ID", "value": "<msg-001@example.com>" }
+      ],
+      "mimeType": "text/plain",
+      "body": {
+        "data": "44OX44Ot44K444Kn44Kv44OI44Gu6YCA5pS244Gn44GZ44CC5p2h6YCa5pmC44Gm44GE44Gg44GN44G+44GZ44CC"
+      },
+      "parts": []
+    }
+  },
+  "replyEmail": {
+    "id": "msg-003",
+    "threadId": "thread-001",
+    "payload": {
+      "headers": [
+        { "name": "Subject", "value": "Re: プロジェクトの進捗確認をお願いします" },
+        { "name": "From", "value": "tanaka@example.com" },
+        { "name": "Message-ID", "value": "<msg-003@example.com>" }
+      ],
+      "mimeType": "text/plain",
+      "body": {
+        "data": "6L+U5Zue44CC6YCA5pS244Gn44GZ44CC"
+      },
+      "parts": []
+    }
+  },
+  "calendarInvite": {
+    "id": "msg-cal-001",
+    "threadId": "thread-cal-001",
+    "payload": {
+      "headers": [
+        { "name": "Subject", "value": "会議の招待" },
+        { "name": "From", "value": "calendar-notification@google.com" }
+      ],
+      "mimeType": "multipart/mixed",
+      "body": {},
+      "parts": [
+        { "mimeType": "text/plain", "body": { "data": "" }, "headers": [] },
+        { "mimeType": "text/calendar", "body": { "data": "" }, "headers": [] }
+      ]
+    }
+  }
+}

--- a/cf-worker/test/fixtures/notion-tasks.json
+++ b/cf-worker/test/fixtures/notion-tasks.json
@@ -1,0 +1,51 @@
+{
+  "queryResponse": {
+    "results": [
+      {
+        "id": "page-001",
+        "url": "https://www.notion.so/page-001",
+        "last_edited_time": "2026-04-20T10:00:00.000Z",
+        "properties": {
+          "タイトル": { "title": [{ "text": { "content": "プロジェクト資料を確認する" } }] },
+          "Due": { "date": { "start": "2026-04-30" } },
+          "Priority": { "select": { "name": "high" } },
+          "Status": { "status": { "name": "未着手" } }
+        }
+      },
+      {
+        "id": "page-002",
+        "url": "https://www.notion.so/page-002",
+        "last_edited_time": "2026-04-10T10:00:00.000Z",
+        "properties": {
+          "タイトル": { "title": [{ "text": { "content": "週次レポートを提出する" } }] },
+          "Due": { "date": { "start": "2026-04-25" } },
+          "Priority": { "select": { "name": "medium" } },
+          "Status": { "status": { "name": "進行中" } }
+        }
+      },
+      {
+        "id": "page-003",
+        "url": "https://www.notion.so/page-003",
+        "last_edited_time": "2026-04-01T10:00:00.000Z",
+        "properties": {
+          "タイトル": { "title": [{ "text": { "content": "古いタスク（14日以上未更新）" } }] },
+          "Due": null,
+          "Priority": { "select": { "name": "low" } },
+          "Status": { "status": { "name": "未着手" } }
+        }
+      }
+    ]
+  },
+  "createResponse": {
+    "id": "page-new-001"
+  },
+  "pageResponse": {
+    "id": "page-001",
+    "archived": false,
+    "properties": {
+      "Status": { "status": { "name": "未着手" } },
+      "Priority": { "select": { "name": "medium" } },
+      "Due": { "date": { "start": "2026-04-30" } }
+    }
+  }
+}

--- a/cf-worker/test/fixtures/telegram-updates.json
+++ b/cf-worker/test/fixtures/telegram-updates.json
@@ -1,0 +1,58 @@
+{
+  "tasksCommand": {
+    "update_id": 1001,
+    "message": {
+      "message_id": 1,
+      "chat": { "id": 123456789 },
+      "text": "/tasks"
+    }
+  },
+  "doneCommand": {
+    "update_id": 1002,
+    "message": {
+      "message_id": 2,
+      "chat": { "id": 123456789 },
+      "text": "/done 1"
+    }
+  },
+  "addCommand": {
+    "update_id": 1003,
+    "message": {
+      "message_id": 3,
+      "chat": { "id": 123456789 },
+      "text": "/add 資料を確認する"
+    }
+  },
+  "dueCommand": {
+    "update_id": 1004,
+    "message": {
+      "message_id": 4,
+      "chat": { "id": 123456789 },
+      "text": "/due 1 2026-05-01"
+    }
+  },
+  "urlMessage": {
+    "update_id": 1005,
+    "message": {
+      "message_id": 5,
+      "chat": { "id": 123456789 },
+      "text": "https://example.com/article"
+    }
+  },
+  "textMessage": {
+    "update_id": 1006,
+    "message": {
+      "message_id": 6,
+      "chat": { "id": 123456789 },
+      "text": "明日までに資料を提出してください"
+    }
+  },
+  "wrongChatMessage": {
+    "update_id": 1007,
+    "message": {
+      "message_id": 7,
+      "chat": { "id": 999999999 },
+      "text": "/tasks"
+    }
+  }
+}

--- a/cf-worker/test/helpers/mocks.ts
+++ b/cf-worker/test/helpers/mocks.ts
@@ -1,0 +1,145 @@
+import { vi } from "vitest";
+import type { Env, Task } from "../../src/types.js";
+
+// ─── In-memory KV mock ───────────────────────────────────────────────────────
+
+export function createMockKV(): KVNamespace {
+  const store = new Map<string, string>();
+
+  return {
+    async get(key: string, type?: string) {
+      const val = store.get(key) ?? null;
+      if (val === null) return null;
+      if (type === "json") return JSON.parse(val);
+      return val;
+    },
+    async put(key: string, value: string | ArrayBuffer, options?: { expirationTtl?: number }) {
+      store.set(key, typeof value === "string" ? value : "");
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list() {
+      return { keys: [...store.keys()].map((name) => ({ name })), list_complete: true, cursor: "" };
+    },
+    async getWithMetadata(key: string) {
+      return { value: store.get(key) ?? null, metadata: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+// ─── In-memory D1 mock ───────────────────────────────────────────────────────
+
+export function createMockD1(): D1Database {
+  const tables: Record<string, Record<string, unknown>[]> = {
+    gmail_thread_map: [],
+    task_sender_map: [],
+    calendar_sync: [],
+    processed_messages: [],
+  };
+
+  const stub = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first<T>() {
+              return null as T | null;
+            },
+            async all<T>() {
+              return { results: [] as T[], success: true, meta: {} };
+            },
+            async run() {
+              return { success: true, meta: {} };
+            },
+          };
+        },
+        async first<T>() {
+          return null as T | null;
+        },
+        async all<T>() {
+          return { results: [] as T[], success: true, meta: {} };
+        },
+        async run() {
+          return { success: true, meta: {} };
+        },
+      };
+    },
+    async exec() {
+      return { count: 0, duration: 0 };
+    },
+    async batch() {
+      return [];
+    },
+  };
+
+  return stub as unknown as D1Database;
+}
+
+// ─── Mock Env ────────────────────────────────────────────────────────────────
+
+export function createMockEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    AGENT_KV: createMockKV(),
+    AGENT_DB: createMockD1(),
+    ANTHROPIC_API_KEY: "test-anthropic-key",
+    NOTION_TOKEN: "test-notion-token",
+    NOTION_TASKS_DB_ID: "test-db-id",
+    TELEGRAM_BOT_TOKEN: "test-bot-token",
+    TELEGRAM_CHAT_ID: "123456789",
+    GOOGLE_CLIENT_ID: "test-client-id",
+    GOOGLE_CLIENT_SECRET: "test-client-secret",
+    GOOGLE_REFRESH_TOKEN: "test-refresh-token",
+    OPERATING_START_HOUR: "8",
+    OPERATING_END_HOUR: "21",
+    ...overrides,
+  };
+}
+
+// ─── Mock fetch helper ───────────────────────────────────────────────────────
+
+export function mockFetch(responses: Array<{ url?: RegExp | string; response: unknown; status?: number }>) {
+  let index = 0;
+  return vi.fn(async (url: string) => {
+    const match = responses[index] ?? responses[responses.length - 1];
+    index++;
+    return new Response(JSON.stringify(match.response), {
+      status: match.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+// ─── Sample tasks ────────────────────────────────────────────────────────────
+
+export function sampleTasks(): Task[] {
+  return [
+    {
+      title: "プロジェクト資料を確認する",
+      due: "2026-04-30",
+      priority: "high",
+      status: "未着手",
+      lastEdited: "2026-04-20",
+      url: "https://notion.so/page-001",
+      pageId: "page-001",
+    },
+    {
+      title: "週次レポートを提出する",
+      due: "2026-04-25",
+      priority: "medium",
+      status: "進行中",
+      lastEdited: "2026-04-10",
+      url: "https://notion.so/page-002",
+      pageId: "page-002",
+    },
+    {
+      title: "古いタスク",
+      due: null,
+      priority: "low",
+      status: "未着手",
+      lastEdited: "2026-04-01",
+      url: "https://notion.so/page-003",
+      pageId: "page-003",
+    },
+  ];
+}

--- a/cf-worker/test/integration/scheduled.test.ts
+++ b/cf-worker/test/integration/scheduled.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockEnv } from "../helpers/mocks.js";
+
+// Import the default export (Worker) from index.ts
+import worker from "../../src/index.js";
+
+// Mock all job handlers
+vi.mock("../../src/handlers/gmail.js", () => ({
+  checkGmail: vi.fn().mockResolvedValue(undefined),
+  learnFromCancelled: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/handlers/calendar.js", () => ({
+  syncCalendar: vi.fn().mockResolvedValue(undefined),
+  sendDueSoonNotice: vi.fn().mockResolvedValue(undefined),
+  sendTaskReminder: vi.fn().mockResolvedValue(undefined),
+  deleteCalendarEventForTask: vi.fn().mockResolvedValue(undefined),
+  getTodaysEvents: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../src/handlers/briefing.js", () => ({
+  sendDailyBriefing: vi.fn().mockResolvedValue(undefined),
+  sendCostReport: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/handlers/escalation.js", () => ({
+  sendEscalationNotice: vi.fn().mockResolvedValue(undefined),
+  sendStaleTasksNotice: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  escapeMd: (t: string) => t,
+  getFileUrl: vi.fn(),
+}));
+
+function makeScheduledEvent(cron: string): ScheduledEvent {
+  return {
+    cron,
+    scheduledTime: Date.now(),
+    type: "scheduled",
+    waitUntil: vi.fn(),
+    noRetry: vi.fn(),
+  } as unknown as ScheduledEvent;
+}
+
+describe("scheduled handler - cron dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches learnFromCancelled for 50 22 * * *", async () => {
+    const env = createMockEnv();
+    const { learnFromCancelled } = await import("../../src/handlers/gmail.js");
+
+    await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
+    expect(learnFromCancelled).toHaveBeenCalledWith(env);
+  });
+
+  it("dispatches checkGmail for 55 22 * * *", async () => {
+    const env = createMockEnv();
+    const { checkGmail } = await import("../../src/handlers/gmail.js");
+
+    await worker.scheduled(makeScheduledEvent("55 22 * * *"), env);
+    expect(checkGmail).toHaveBeenCalledWith(env);
+  });
+
+  it("dispatches syncCalendar for 57 22 * * *", async () => {
+    const env = createMockEnv();
+    const { syncCalendar } = await import("../../src/handlers/calendar.js");
+
+    await worker.scheduled(makeScheduledEvent("57 22 * * *"), env);
+    expect(syncCalendar).toHaveBeenCalledWith(env);
+  });
+
+  it("dispatches sendDailyBriefing for 0 23 * * *", async () => {
+    const env = createMockEnv();
+    const { sendDailyBriefing } = await import("../../src/handlers/briefing.js");
+
+    await worker.scheduled(makeScheduledEvent("0 23 * * *"), env);
+    expect(sendDailyBriefing).toHaveBeenCalledWith(env);
+  });
+
+  it("dispatches sendStaleTasksNotice for 0 0 * * 1", async () => {
+    const env = createMockEnv();
+    const { sendStaleTasksNotice } = await import("../../src/handlers/escalation.js");
+
+    await worker.scheduled(makeScheduledEvent("0 0 * * 1"), env);
+    expect(sendStaleTasksNotice).toHaveBeenCalledWith(env);
+  });
+
+  it("sends error notification to Telegram when job throws", async () => {
+    const env = createMockEnv();
+    const { checkGmail } = await import("../../src/handlers/gmail.js");
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+
+    (checkGmail as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("API timeout"));
+
+    await worker.scheduled(makeScheduledEvent("55 22 * * *"), env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("エラー"));
+  });
+
+  it("logs warning for unknown cron expression", async () => {
+    const env = createMockEnv();
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await worker.scheduled(makeScheduledEvent("0 0 1 1 *"), env);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown cron"), "0 0 1 1 *");
+  });
+});
+
+describe("fetch handler", () => {
+  it("responds to POST /webhook with OK", async () => {
+    const env = createMockEnv();
+    const req = new Request("https://example.com/webhook", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ update_id: 1 }),
+    });
+    const resp = await worker.fetch(req, env);
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toBe("OK");
+  });
+
+  it("responds to unknown paths with 200", async () => {
+    const env = createMockEnv();
+    const req = new Request("https://example.com/health");
+    const resp = await worker.fetch(req, env);
+    expect(resp.status).toBe(200);
+  });
+});

--- a/cf-worker/test/integration/scheduled.test.ts
+++ b/cf-worker/test/integration/scheduled.test.ts
@@ -57,28 +57,27 @@ describe("scheduled handler - cron dispatch", () => {
     expect(learnFromCancelled).toHaveBeenCalledWith(env);
   });
 
-  it("dispatches checkGmail for 55 22 * * *", async () => {
+  it("50 22 * * * (morning_prep) runs gmail, calendar, escalation", async () => {
     const env = createMockEnv();
     const { checkGmail } = await import("../../src/handlers/gmail.js");
-
-    await worker.scheduled(makeScheduledEvent("55 22 * * *"), env);
-    expect(checkGmail).toHaveBeenCalledWith(env);
-  });
-
-  it("dispatches syncCalendar for 57 22 * * *", async () => {
-    const env = createMockEnv();
     const { syncCalendar } = await import("../../src/handlers/calendar.js");
+    const { sendEscalationNotice } = await import("../../src/handlers/escalation.js");
 
-    await worker.scheduled(makeScheduledEvent("57 22 * * *"), env);
+    await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
+    expect(checkGmail).toHaveBeenCalledWith(env);
     expect(syncCalendar).toHaveBeenCalledWith(env);
+    expect(sendEscalationNotice).toHaveBeenCalledWith(env);
   });
 
-  it("dispatches sendDailyBriefing for 0 23 * * *", async () => {
+  it("0 23 * * * (morning_briefing) runs briefing, cost, due_soon", async () => {
     const env = createMockEnv();
-    const { sendDailyBriefing } = await import("../../src/handlers/briefing.js");
+    const { sendDailyBriefing, sendCostReport } = await import("../../src/handlers/briefing.js");
+    const { sendDueSoonNotice } = await import("../../src/handlers/calendar.js");
 
     await worker.scheduled(makeScheduledEvent("0 23 * * *"), env);
     expect(sendDailyBriefing).toHaveBeenCalledWith(env);
+    expect(sendCostReport).toHaveBeenCalledWith(env);
+    expect(sendDueSoonNotice).toHaveBeenCalledWith(env);
   });
 
   it("dispatches sendStaleTasksNotice for 0 0 * * 1", async () => {
@@ -96,7 +95,7 @@ describe("scheduled handler - cron dispatch", () => {
 
     (checkGmail as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("API timeout"));
 
-    await worker.scheduled(makeScheduledEvent("55 22 * * *"), env);
+    await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
     expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("エラー"));
   });
 

--- a/cf-worker/test/integration/telegram-webhook.test.ts
+++ b/cf-worker/test/integration/telegram-webhook.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index.js";
+import { createMockEnv, sampleTasks } from "../helpers/mocks.js";
+import telegramFixtures from "../fixtures/telegram-updates.json" assert { type: "json" };
+
+vi.mock("../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn().mockResolvedValue([]),
+  addTask: vi.fn().mockResolvedValue("page-new"),
+  completeTask: vi.fn().mockResolvedValue(undefined),
+  cancelTask: vi.fn().mockResolvedValue(undefined),
+  updateTaskDue: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  getFileUrl: vi.fn(),
+  escapeMd: (t: string) => t,
+}));
+
+vi.mock("../../src/clients/anthropic.js", () => ({
+  analyzeEmail: vi.fn(),
+  extractTasksFromText: vi.fn().mockResolvedValue([]),
+  extractTasksFromUrlContent: vi.fn().mockResolvedValue([]),
+  extractTasksFromImage: vi.fn().mockResolvedValue([]),
+  summarizeDay: vi.fn().mockResolvedValue("ブリーフィング"),
+}));
+
+vi.mock("../../src/handlers/calendar.js", () => ({
+  deleteCalendarEventForTask: vi.fn().mockResolvedValue(undefined),
+  syncCalendar: vi.fn().mockResolvedValue(undefined),
+  sendDueSoonNotice: vi.fn().mockResolvedValue(undefined),
+  sendTaskReminder: vi.fn().mockResolvedValue(undefined),
+  getTodaysEvents: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../src/handlers/briefing.js", () => ({
+  sendDailyBriefing: vi.fn().mockResolvedValue(undefined),
+  sendCostReport: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/handlers/escalation.js", () => ({
+  sendEscalationNotice: vi.fn().mockResolvedValue(undefined),
+  sendStaleTasksNotice: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/storage/d1.js", () => ({
+  getSenderForTask: vi.fn().mockResolvedValue(null),
+  getThreadMapEntry: vi.fn().mockResolvedValue(null),
+  setThreadMapEntry: vi.fn().mockResolvedValue(undefined),
+  setSenderForTask: vi.fn().mockResolvedValue(undefined),
+  deleteSenderMapEntry: vi.fn().mockResolvedValue(undefined),
+  getAllSenderMap: vi.fn().mockResolvedValue(new Map()),
+  isProcessed: vi.fn().mockResolvedValue(false),
+  markProcessed: vi.fn().mockResolvedValue(undefined),
+  cleanOldProcessed: vi.fn().mockResolvedValue(undefined),
+  getCalendarSync: vi.fn().mockResolvedValue(null),
+  setCalendarSync: vi.fn().mockResolvedValue(undefined),
+  deleteCalendarSync: vi.fn().mockResolvedValue(undefined),
+  getAllCalendarSync: vi.fn().mockResolvedValue(new Map()),
+}));
+
+function webhookRequest(update: unknown): Request {
+  return new Request("https://example.com/webhook", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(update),
+  });
+}
+
+describe("Telegram webhook E2E", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("/add creates task and responds OK", async () => {
+    const env = createMockEnv();
+    const { addTask } = await import("../../src/clients/notion.js");
+
+    const resp = await worker.fetch(webhookRequest(telegramFixtures.addCommand), env);
+    expect(resp.status).toBe(200);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ title: "資料を確認する" }),
+    );
+  });
+
+  it("/tasks sends task list", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../src/clients/notion.js");
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+
+    const resp = await worker.fetch(webhookRequest(telegramFixtures.tasksCommand), env);
+    expect(resp.status).toBe(200);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("タスク一覧"));
+  });
+
+  it("ignores messages from wrong chat ID", async () => {
+    const env = createMockEnv();
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+
+    await worker.fetch(webhookRequest(telegramFixtures.wrongChatMessage), env);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns OK even if handler throws", async () => {
+    const env = createMockEnv();
+    const { addTask } = await import("../../src/clients/notion.js");
+    (addTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Notion error"));
+
+    const resp = await worker.fetch(webhookRequest(telegramFixtures.addCommand), env);
+    expect(resp.status).toBe(200);
+  });
+});

--- a/cf-worker/test/unit/clients/anthropic.test.ts
+++ b/cf-worker/test/unit/clients/anthropic.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { analyzeEmail, extractTasksFromText, extractTasksFromUrlContent } from "../../../src/clients/anthropic.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+import claudeFixtures from "../../fixtures/claude-responses.json" assert { type: "json" };
+
+describe("analyzeEmail", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns summary and tasks from valid response", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(claudeFixtures.analyzeEmailResponse), { status: 200 }),
+    ));
+
+    const result = await analyzeEmail(env, "プロジェクトの進捗確認", "内容...");
+    expect(result.summary).toContain("田中さん");
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].title).toBe("プロジェクト進捗を報告する");
+    expect(result.tasks[0].priority).toBe("high");
+  });
+
+  it("returns empty tasks array for newsletters", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(claudeFixtures.analyzeEmailNoTasksResponse), { status: 200 }),
+    ));
+
+    const result = await analyzeEmail(env, "ニュースレター", "広告内容...");
+    expect(result.tasks).toHaveLength(0);
+  });
+
+  it("handles malformed JSON response gracefully", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        content: [{ type: "text", text: "このメールはタスクを必要としません。" }],
+        usage: { input_tokens: 50, output_tokens: 10 },
+      }), { status: 200 }),
+    ));
+
+    const result = await analyzeEmail(env, "件名", "本文");
+    expect(result.tasks).toEqual([]);
+    expect(typeof result.summary).toBe("string");
+  });
+});
+
+describe("extractTasksFromText", () => {
+  it("extracts task list from response", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(claudeFixtures.extractTasksResponse), { status: 200 }),
+    ));
+
+    const tasks = await extractTasksFromText(env, "extract_tasks", "件名", "本文");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].title).toBe("プロジェクト資料を確認する");
+    expect(tasks[0].due).toBe("2026-04-30");
+  });
+
+  it("returns empty array when no JSON list in response", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        content: [{ type: "text", text: "タスクはありません。" }],
+        usage: { input_tokens: 30, output_tokens: 5 },
+      }), { status: 200 }),
+    ));
+
+    const tasks = await extractTasksFromText(env, "test", "件名", "本文");
+    expect(tasks).toEqual([]);
+  });
+});
+
+describe("extractTasksFromUrlContent", () => {
+  it("passes URL as subject to Claude", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(claudeFixtures.extractTasksResponse), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await extractTasksFromUrlContent(env, "https://example.com/task", "コンテンツ");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.messages[0].content).toContain("https://example.com/task");
+  });
+});

--- a/cf-worker/test/unit/clients/google-auth.test.ts
+++ b/cf-worker/test/unit/clients/google-auth.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getAccessToken } from "../../../src/clients/google-auth.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+
+describe("getAccessToken", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns cached token when still valid", async () => {
+    const env = createMockEnv();
+    const cache = { token: "cached-token", expiresAt: Date.now() + 3_600_000 };
+    await env.AGENT_KV.put("google:access_token", JSON.stringify(cache));
+
+    const token = await getAccessToken(env);
+    expect(token).toBe("cached-token");
+  });
+
+  it("refreshes token when cache is missing", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "new-token", expires_in: 3600 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ));
+
+    const token = await getAccessToken(env);
+    expect(token).toBe("new-token");
+  });
+
+  it("refreshes token when cached token is about to expire (within 60s)", async () => {
+    const env = createMockEnv();
+    const cache = { token: "old-token", expiresAt: Date.now() + 30_000 };
+    await env.AGENT_KV.put("google:access_token", JSON.stringify(cache));
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "fresh-token", expires_in: 3600 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ));
+
+    const token = await getAccessToken(env);
+    expect(token).toBe("fresh-token");
+  });
+
+  it("throws when OAuth endpoint returns error", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response("invalid_grant", { status: 400 }),
+    ));
+
+    await expect(getAccessToken(env)).rejects.toThrow("400");
+  });
+});

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks } from "../../../src/clients/notion.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+import notionFixtures from "../../fixtures/notion-tasks.json" assert { type: "json" };
+
+describe("addTask", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a task page with required properties", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 })),
+    );
+
+    const id = await addTask(env, { title: "テストタスク", priority: "high", source: "Gmail" });
+    expect(id).toBe("page-new-001");
+  });
+
+  it("sets Due property when due date provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "期限付きタスク", due: "2026-05-01", priority: "medium" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties.Due.date.start).toBe("2026-05-01");
+  });
+
+  it("appends checklist as to_do blocks when provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "チェックリスト付き" }, ["項目1", "項目2"]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.children).toHaveLength(2);
+    expect(body.children[0].type).toBe("to_do");
+    expect(body.children[0].to_do.rich_text[0].text.content).toBe("項目1");
+  });
+});
+
+describe("getOpenTasks", () => {
+  it("returns tasks with parsed properties", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data_sources: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.queryResponse), { status: 200 })),
+    );
+
+    const tasks = await getOpenTasks(env);
+    expect(tasks).toHaveLength(3);
+    expect(tasks[0].title).toBe("プロジェクト資料を確認する");
+    expect(tasks[0].priority).toBe("high");
+    expect(tasks[0].due).toBe("2026-04-30");
+    expect(tasks[0].pageId).toBe("page-001");
+  });
+
+  it("uses data_sources.query when data_source_id is available", async () => {
+    const env = createMockEnv();
+    await env.AGENT_KV.put("notion:data_source_id", "ds-id-001");
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(notionFixtures.queryResponse), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getOpenTasks(env);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/data_sources/ds-id-001/query");
+  });
+
+  it("falls back to databases.query when data_sources.query fails", async () => {
+    const env = createMockEnv();
+    await env.AGENT_KV.put("notion:data_source_id", "ds-id-001");
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.queryResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tasks = await getOpenTasks(env);
+    expect(tasks).toHaveLength(3);
+    const fallbackUrl = fetchMock.mock.calls[1][0] as string;
+    expect(fallbackUrl).toContain(`/databases/${env.NOTION_TASKS_DB_ID}/query`);
+  });
+});
+
+describe("completeTask / cancelTask", () => {
+  it("updates status to 完了", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await completeTask(env, "page-001");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties.Status.status.name).toBe("完了");
+  });
+
+  it("updates status to 中止", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await cancelTask(env, "page-001");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties.Status.status.name).toBe("中止");
+  });
+});
+
+describe("updateTaskDue", () => {
+  it("sets Due date", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await updateTaskDue(env, "page-001", "2026-06-01");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties.Due.date.start).toBe("2026-06-01");
+  });
+});
+
+describe("escalatePriorityTasks", () => {
+  it("escalates medium tasks due within 3 days", async () => {
+    const env = createMockEnv();
+    const today = new Date();
+    const dueSoon = new Date(today);
+    dueSoon.setDate(dueSoon.getDate() + 2);
+    const dueStr = dueSoon.toISOString().slice(0, 10);
+
+    const escalatableTask = {
+      id: "page-escalate",
+      url: "",
+      last_edited_time: today.toISOString(),
+      properties: {
+        "タイトル": { title: [{ text: { content: "緊急タスク" } }] },
+        Due: { date: { start: dueStr } },
+        Priority: { select: { name: "medium" } },
+        Status: { status: { name: "未着手" } },
+      },
+    };
+
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data_sources: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ results: [escalatableTask] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 })),
+    );
+
+    const escalated = await escalatePriorityTasks(env);
+    expect(escalated).toHaveLength(1);
+    expect(escalated[0].title).toBe("緊急タスク");
+  });
+});

--- a/cf-worker/test/unit/clients/telegram.test.ts
+++ b/cf-worker/test/unit/clients/telegram.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendMessage, escapeMd } from "../../../src/clients/telegram.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+
+describe("escapeMd", () => {
+  it("escapes Markdown special characters", () => {
+    expect(escapeMd("hello *world*")).toBe("hello \\*world\\*");
+    expect(escapeMd("code `snippet`")).toBe("code \\`snippet\\`");
+    expect(escapeMd("[link]")).toBe("\\[link]");  // Python behavior: only [ is escaped, not ]
+    expect(escapeMd("_italic_")).toBe("\\_italic\\_");
+  });
+
+  it("does not alter regular text", () => {
+    expect(escapeMd("hello world")).toBe("hello world");
+  });
+});
+
+describe("sendMessage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends a short message in one request", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendMessage(env, "Hello");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.text).toBe("Hello");
+    expect(body.chat_id).toBe("123456789");
+    expect(body.parse_mode).toBe("Markdown");
+  });
+
+  it("splits messages longer than 4096 characters", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const longText = "A".repeat(5000);
+    await sendMessage(env, longText);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when Telegram API returns error", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response("Unauthorized", { status: 401 }),
+    ));
+
+    await expect(sendMessage(env, "test")).rejects.toThrow("401");
+  });
+});

--- a/cf-worker/test/unit/handlers/calendar.test.ts
+++ b/cf-worker/test/unit/handlers/calendar.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendDueSoonNotice } from "../../../src/handlers/calendar.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+import type { Task } from "../../../src/types.js";
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/clients/gcal-api.js", () => ({
+  getTodaysEvents: vi.fn().mockResolvedValue([]),
+  insertEvent: vi.fn().mockResolvedValue("event-id"),
+  deleteEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/storage/d1.js", () => ({
+  getAllCalendarSync: vi.fn().mockResolvedValue(new Map()),
+  getCalendarSync: vi.fn().mockResolvedValue(null),
+  setCalendarSync: vi.fn().mockResolvedValue(undefined),
+  deleteCalendarSync: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("sendDueSoonNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends notice for tasks due today and tomorrow", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+    const today = now.toISOString().slice(0, 10);
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+
+    const tasks: Task[] = [
+      { title: "今日期限タスク", due: today, priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+      { title: "明日期限タスク", due: tomorrowStr, priority: "medium", status: "未着手", lastEdited: null, url: "", pageId: "p2" },
+      { title: "来週のタスク", due: "2099-01-01", priority: "low", status: "未着手", lastEdited: null, url: "", pageId: "p3" },
+    ];
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
+
+    await sendDueSoonNotice(env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("今日期限タスク"));
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("明日期限タスク"));
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.not.stringContaining("来週のタスク"));
+  });
+
+  it("does not send when no tasks due soon", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "来月のタスク", due: "2099-01-01", priority: "low", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await sendDueSoonNotice(env);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/cf-worker/test/unit/handlers/escalation.test.ts
+++ b/cf-worker/test/unit/handlers/escalation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendEscalationNotice, sendStaleTasksNotice } from "../../../src/handlers/escalation.js";
+import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
+import type { Task } from "../../../src/types.js";
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+  escalatePriorityTasks: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("sendEscalationNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends notice when tasks are escalated", async () => {
+    const env = createMockEnv();
+    const { escalatePriorityTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (escalatePriorityTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "緊急対応", due: "2026-04-27", priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await sendEscalationNotice(env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("緊急対応"));
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("high に昇格"));
+  });
+
+  it("does not send when no tasks escalated", async () => {
+    const env = createMockEnv();
+    const { escalatePriorityTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (escalatePriorityTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await sendEscalationNotice(env);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendStaleTasksNotice", () => {
+  it("reports tasks not updated for 14+ days", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    const tasks = sampleTasks(); // page-003 has lastEdited: "2026-04-01" (>14 days before 2026-04-25)
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
+
+    await sendStaleTasksNotice(env);
+    // At least one task should be reported as stale relative to today's date in tests
+    // (depends on test execution date, so we just verify it runs without error)
+  });
+
+  it("does not send when no stale tasks", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    // Reset to fresh implementation (clearAllMocks doesn't reset mockResolvedValue)
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockReset();
+
+    // All tasks updated recently (future date ensures they're never stale)
+    const freshTasks: Task[] = [
+      { title: "新しいタスク", due: null, priority: "medium", status: "未着手", lastEdited: "2099-01-01", url: "", pageId: "p1" },
+    ];
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(freshTasks);
+    (sendMessage as ReturnType<typeof vi.fn>).mockReset().mockResolvedValue(undefined);
+
+    await sendStaleTasksNotice(env);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkGmail, learnFromCancelled } from "../../../src/handlers/gmail.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+import gmailFixtures from "../../fixtures/gmail-messages.json" assert { type: "json" };
+
+vi.mock("../../../src/clients/gmail-api.js", () => ({
+  listAllMessages: vi.fn(),
+  getMessage: vi.fn(),
+  parseMessage: vi.fn(),
+  isCalendarInvite: vi.fn().mockReturnValue(false),
+  archiveMessage: vi.fn().mockResolvedValue(undefined),
+  addLabel: vi.fn().mockResolvedValue(undefined),
+  getOrCreateLabel: vi.fn().mockResolvedValue("label-id-001"),
+}));
+
+vi.mock("../../../src/clients/anthropic.js", () => ({
+  analyzeEmail: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  addTask: vi.fn(),
+  updateTaskFromReply: vi.fn(),
+  getTaskStatus: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  escapeMd: (t: string) => t,
+}));
+
+vi.mock("../../../src/storage/d1.js", () => ({
+  getThreadMapEntry: vi.fn(),
+  setThreadMapEntry: vi.fn().mockResolvedValue(undefined),
+  getSenderForTask: vi.fn(),
+  setSenderForTask: vi.fn().mockResolvedValue(undefined),
+  deleteSenderMapEntry: vi.fn().mockResolvedValue(undefined),
+  getAllSenderMap: vi.fn().mockResolvedValue(new Map()),
+  isProcessed: vi.fn().mockResolvedValue(false),
+  markProcessed: vi.fn().mockResolvedValue(undefined),
+  cleanOldProcessed: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("checkGmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new task for new thread", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry } = await import("../../../src/storage/d1.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-001", threadId: "thread-001" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "プロジェクトの進捗確認",
+      body: "内容",
+      senderEmail: "tanaka@example.com",
+      threadId: "thread-001",
+      gmailUrl: "https://mail.google.com/mail/u/0/#search/rfc822msgid:",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "進捗確認の依頼",
+      tasks: [{ title: "進捗を報告する", priority: "high", due: "2026-04-30" }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-new-001");
+
+    await checkGmail(env);
+    expect(addTask).toHaveBeenCalledTimes(1);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ title: "プロジェクトの進捗確認", source: "Gmail" }),
+      ["進捗を報告する"],
+    );
+  });
+
+  it("updates existing task for reply email (same threadId)", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask, updateTaskFromReply } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry } = await import("../../../src/storage/d1.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-003", threadId: "thread-001" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.replyEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "Re: プロジェクト",
+      body: "返信内容",
+      senderEmail: "tanaka@example.com",
+      threadId: "thread-001",
+      gmailUrl: "https://mail.google.com/",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "追加確認依頼",
+      tasks: [{ title: "追加確認を実施する", priority: "medium", due: null }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue("existing-page-id");
+
+    await checkGmail(env);
+    expect(updateTaskFromReply).toHaveBeenCalledWith(
+      env,
+      "existing-page-id",
+      ["追加確認を実施する"],
+      "medium",
+      null,
+    );
+    expect(addTask).not.toHaveBeenCalled();
+  });
+
+  it("skips blocked senders", async () => {
+    const env = createMockEnv();
+    await env.AGENT_KV.put("no_task_senders", "spam@example.com");
+
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-spam", threadId: "thread-spam" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "スパム",
+      body: "",
+      senderEmail: "spam@example.com",
+      threadId: "thread-spam",
+      gmailUrl: "",
+    });
+
+    await checkGmail(env);
+    expect(analyzeEmail).not.toHaveBeenCalled();
+    expect(addTask).not.toHaveBeenCalled();
+  });
+
+  it("skips already-processed messages", async () => {
+    const env = createMockEnv();
+    const { listAllMessages } = await import("../../../src/clients/gmail-api.js");
+    const { isProcessed } = await import("../../../src/storage/d1.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-already-done", threadId: "t1" }]);
+    (isProcessed as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    await checkGmail(env);
+    expect(analyzeEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips calendar invite emails", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, isCalendarInvite } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-cal", threadId: "t-cal" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.calendarInvite);
+    (isCalendarInvite as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    await checkGmail(env);
+    expect(analyzeEmail).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no new messages", async () => {
+    const env = createMockEnv();
+    const { listAllMessages } = await import("../../../src/clients/gmail-api.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await checkGmail(env);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("learnFromCancelled", () => {
+  it("adds cancelled task sender to blocklist", async () => {
+    const env = createMockEnv();
+    const { getAllSenderMap } = await import("../../../src/storage/d1.js");
+    const { getTaskStatus } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getAllSenderMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Map([["page-cancelled", "newsletter@example.com"]]),
+    );
+    (getTaskStatus as ReturnType<typeof vi.fn>).mockResolvedValue("中止");
+
+    await learnFromCancelled(env);
+
+    const senders = await env.AGENT_KV.get("no_task_senders");
+    expect(senders).toContain("newsletter@example.com");
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("newsletter@example.com"));
+  });
+
+  it("removes completed task from sender_map without adding to blocklist", async () => {
+    const env = createMockEnv();
+    const { getAllSenderMap, deleteSenderMapEntry } = await import("../../../src/storage/d1.js");
+    const { getTaskStatus } = await import("../../../src/clients/notion.js");
+
+    (getAllSenderMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Map([["page-done", "friend@example.com"]]),
+    );
+    (getTaskStatus as ReturnType<typeof vi.fn>).mockResolvedValue("完了");
+
+    await learnFromCancelled(env);
+
+    // Completed task sender should NOT be added to blocklist
+    const { getNoTaskSenders: getBlocklist } = await import("../../../src/storage/kv.js");
+    const senders = await getBlocklist(env);
+    expect(senders.has("friend@example.com")).toBe(false);
+    expect(deleteSenderMapEntry).toHaveBeenCalledWith(env, "page-done");
+  });
+});

--- a/cf-worker/test/unit/handlers/task-formatter.test.ts
+++ b/cf-worker/test/unit/handlers/task-formatter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fmtDue, sortTasks, formatTaskList } from "../../../src/handlers/task-formatter.js";
+import { sampleTasks } from "../../helpers/mocks.js";
+import type { Task } from "../../../src/types.js";
+
+describe("fmtDue", () => {
+  it("returns empty string for null", () => {
+    expect(fmtDue(null)).toBe("");
+  });
+
+  it("returns 今日 for today's date", () => {
+    const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+    const today = now.toISOString().slice(0, 10);
+    expect(fmtDue(today)).toBe("今日");
+  });
+
+  it("returns 明日 for tomorrow", () => {
+    const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    expect(fmtDue(tomorrow.toISOString().slice(0, 10))).toBe("明日");
+  });
+
+  it("returns 明後日 for two days from now", () => {
+    const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+    const dayAfterTomorrow = new Date(now);
+    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
+    expect(fmtDue(dayAfterTomorrow.toISOString().slice(0, 10))).toBe("明後日");
+  });
+
+  it("returns formatted date string for far future dates", () => {
+    expect(fmtDue("2030-12-25")).toMatch(/2030年12月25日/);
+  });
+});
+
+describe("sortTasks", () => {
+  it("sorts by status → priority → due date", () => {
+    const tasks: Task[] = [
+      { title: "C", due: "2026-05-01", priority: "low", status: "未着手", lastEdited: null, url: "", pageId: "c" },
+      { title: "A", due: "2026-04-25", priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "a" },
+      { title: "B", due: "2026-04-30", priority: "medium", status: "進行中", lastEdited: null, url: "", pageId: "b" },
+    ];
+
+    const sorted = sortTasks(tasks);
+    // 未着手 comes before 進行中 (STATUS_ORDER)
+    expect(sorted[0].title).toBe("A"); // high priority, earlier due
+    expect(sorted[1].title).toBe("C"); // low priority
+    expect(sorted[2].title).toBe("B"); // 進行中 status
+  });
+
+  it("sorts tasks without due date after tasks with due date", () => {
+    const tasks: Task[] = [
+      { title: "No Due", due: null, priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "x" },
+      { title: "Has Due", due: "2026-04-20", priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "y" },
+    ];
+
+    const sorted = sortTasks(tasks);
+    expect(sorted[0].title).toBe("Has Due");
+  });
+});
+
+describe("formatTaskList", () => {
+  it("includes priority icons and status headers", () => {
+    const tasks = sampleTasks();
+    const result = formatTaskList(tasks);
+    expect(result).toContain("🔴");  // high priority icon
+    expect(result).toContain("📋 未着手");
+    expect(result).toContain("▶️ 進行中");
+  });
+
+  it("includes numbered prefix when numbered=true", () => {
+    const tasks = sampleTasks().slice(0, 1);
+    const result = formatTaskList(tasks, true);
+    expect(result).toContain("1. ");
+  });
+
+  it("uses bullet prefix when numbered=false", () => {
+    const tasks = sampleTasks().slice(0, 1);
+    const result = formatTaskList(tasks, false);
+    expect(result).toContain("• ");
+    expect(result).not.toContain("1. ");
+  });
+});

--- a/cf-worker/test/unit/handlers/telegram.test.ts
+++ b/cf-worker/test/unit/handlers/telegram.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleTelegramWebhook } from "../../../src/handlers/telegram.js";
+import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
+import telegramFixtures from "../../fixtures/telegram-updates.json" assert { type: "json" };
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+  addTask: vi.fn().mockResolvedValue("page-new"),
+  completeTask: vi.fn().mockResolvedValue(undefined),
+  cancelTask: vi.fn().mockResolvedValue(undefined),
+  updateTaskDue: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  getFileUrl: vi.fn(),
+  escapeMd: (t: string) => t,
+}));
+
+vi.mock("../../../src/handlers/calendar.js", () => ({
+  deleteCalendarEventForTask: vi.fn().mockResolvedValue(undefined),
+  getTodaysEvents: vi.fn().mockResolvedValue([]),
+  syncCalendar: vi.fn().mockResolvedValue(undefined),
+  sendDueSoonNotice: vi.fn().mockResolvedValue(undefined),
+  sendTaskReminder: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/handlers/briefing.js", () => ({
+  sendDailyBriefing: vi.fn().mockResolvedValue(undefined),
+  sendCostReport: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/clients/anthropic.js", () => ({
+  extractTasksFromText: vi.fn().mockResolvedValue([{ title: "テストタスク", due: null, priority: "medium" }]),
+  extractTasksFromUrlContent: vi.fn().mockResolvedValue([]),
+  extractTasksFromImage: vi.fn().mockResolvedValue([]),
+  summarizeDay: vi.fn().mockResolvedValue("今日のブリーフィング"),
+}));
+
+vi.mock("../../../src/storage/d1.js", () => ({
+  getSenderForTask: vi.fn().mockResolvedValue(null),
+  getThreadMapEntry: vi.fn().mockResolvedValue(null),
+  setThreadMapEntry: vi.fn().mockResolvedValue(undefined),
+  setSenderForTask: vi.fn().mockResolvedValue(undefined),
+  deleteSenderMapEntry: vi.fn().mockResolvedValue(undefined),
+  getAllSenderMap: vi.fn().mockResolvedValue(new Map()),
+  isProcessed: vi.fn().mockResolvedValue(false),
+  markProcessed: vi.fn().mockResolvedValue(undefined),
+  cleanOldProcessed: vi.fn().mockResolvedValue(undefined),
+  getCalendarSync: vi.fn().mockResolvedValue(null),
+  setCalendarSync: vi.fn().mockResolvedValue(undefined),
+  deleteCalendarSync: vi.fn().mockResolvedValue(undefined),
+  getAllCalendarSync: vi.fn().mockResolvedValue(new Map()),
+}));
+
+describe("handleTelegramWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores messages from wrong chat", async () => {
+    const env = createMockEnv();
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    await handleTelegramWebhook(env, telegramFixtures.wrongChatMessage);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores updates with no message", async () => {
+    const env = createMockEnv();
+    await handleTelegramWebhook(env, { update_id: 999 });
+    // should not throw
+  });
+
+  it("/add command creates a task", async () => {
+    const env = createMockEnv();
+    const { addTask } = await import("../../../src/clients/notion.js");
+
+    await handleTelegramWebhook(env, telegramFixtures.addCommand);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ title: "資料を確認する", source: "Telegram" }),
+    );
+  });
+
+  it("/tasks command fetches open tasks and caches them", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+
+    await handleTelegramWebhook(env, telegramFixtures.tasksCommand);
+    expect(getOpenTasks).toHaveBeenCalledWith(env);
+  });
+
+  it("/done command without prior /tasks sends guidance message", async () => {
+    const env = createMockEnv();
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    // Empty cache → should send hint message
+    await handleTelegramWebhook(env, telegramFixtures.doneCommand);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("/tasks"));
+  });
+
+  it("/due validates date format", async () => {
+    const env = createMockEnv();
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    const badDueUpdate = {
+      update_id: 9999,
+      message: { message_id: 99, chat: { id: 123456789 }, text: "/due 1 not-a-date" },
+    };
+    await handleTelegramWebhook(env, badDueUpdate);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("YYYY-MM-DD"));
+  });
+});

--- a/cf-worker/test/unit/storage/d1.test.ts
+++ b/cf-worker/test/unit/storage/d1.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  getThreadMapEntry,
+  setThreadMapEntry,
+  getSenderForTask,
+  setSenderForTask,
+  deleteSenderMapEntry,
+  getAllSenderMap,
+  getCalendarSync,
+  setCalendarSync,
+  deleteCalendarSync,
+  getAllCalendarSync,
+  isProcessed,
+  markProcessed,
+  cleanOldProcessed,
+} from "../../../src/storage/d1.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+
+// These tests use the mock D1 which returns null/empty by default.
+// The real behavior is tested via integration tests with miniflare.
+
+describe("gmail_thread_map (mock D1)", () => {
+  it("returns null for missing thread", async () => {
+    const env = createMockEnv();
+    expect(await getThreadMapEntry(env, "thread-nonexistent")).toBeNull();
+  });
+});
+
+describe("task_sender_map (mock D1)", () => {
+  it("returns null for missing pageId", async () => {
+    const env = createMockEnv();
+    expect(await getSenderForTask(env, "page-nonexistent")).toBeNull();
+  });
+
+  it("getAllSenderMap returns empty map when no entries", async () => {
+    const env = createMockEnv();
+    const map = await getAllSenderMap(env);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("calendar_sync (mock D1)", () => {
+  it("returns null for missing pageId", async () => {
+    const env = createMockEnv();
+    expect(await getCalendarSync(env, "page-nonexistent")).toBeNull();
+  });
+
+  it("getAllCalendarSync returns empty map when no entries", async () => {
+    const env = createMockEnv();
+    const map = await getAllCalendarSync(env);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("processed_messages (mock D1)", () => {
+  it("isProcessed returns false for unknown message", async () => {
+    const env = createMockEnv();
+    expect(await isProcessed(env, "msg-unknown")).toBe(false);
+  });
+});

--- a/cf-worker/test/unit/storage/kv.test.ts
+++ b/cf-worker/test/unit/storage/kv.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  getTelegramOffset,
+  setTelegramOffset,
+  getTaskCache,
+  setTaskCache,
+  getNoTaskSenders,
+  addNoTaskSender,
+  removeNoTaskSender,
+  recordUsage,
+  getDailyUsage,
+} from "../../../src/storage/kv.js";
+import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
+
+describe("telegram offset", () => {
+  it("returns 0 when not set", async () => {
+    const env = createMockEnv();
+    expect(await getTelegramOffset(env)).toBe(0);
+  });
+
+  it("persists and retrieves offset", async () => {
+    const env = createMockEnv();
+    await setTelegramOffset(env, 12345);
+    expect(await getTelegramOffset(env)).toBe(12345);
+  });
+});
+
+describe("task cache", () => {
+  it("returns empty array when not set", async () => {
+    const env = createMockEnv();
+    expect(await getTaskCache(env)).toEqual([]);
+  });
+
+  it("persists and retrieves task list", async () => {
+    const env = createMockEnv();
+    const tasks = sampleTasks();
+    await setTaskCache(env, tasks);
+    const result = await getTaskCache(env);
+    expect(result).toHaveLength(3);
+    expect(result[0].pageId).toBe("page-001");
+  });
+});
+
+describe("no-task senders blocklist", () => {
+  it("returns empty set when not set", async () => {
+    const env = createMockEnv();
+    const senders = await getNoTaskSenders(env);
+    expect(senders.size).toBe(0);
+  });
+
+  it("adds sender to blocklist", async () => {
+    const env = createMockEnv();
+    await addNoTaskSender(env, "spam@example.com");
+    const senders = await getNoTaskSenders(env);
+    expect(senders.has("spam@example.com")).toBe(true);
+  });
+
+  it("normalizes email to lowercase when adding", async () => {
+    const env = createMockEnv();
+    await addNoTaskSender(env, "SPAM@EXAMPLE.COM");
+    const senders = await getNoTaskSenders(env);
+    expect(senders.has("spam@example.com")).toBe(true);
+  });
+
+  it("removes existing sender and returns true", async () => {
+    const env = createMockEnv();
+    await addNoTaskSender(env, "spam@example.com");
+    const result = await removeNoTaskSender(env, "spam@example.com");
+    expect(result).toBe(true);
+    const senders = await getNoTaskSenders(env);
+    expect(senders.has("spam@example.com")).toBe(false);
+  });
+
+  it("returns false when sender not in blocklist", async () => {
+    const env = createMockEnv();
+    const result = await removeNoTaskSender(env, "unknown@example.com");
+    expect(result).toBe(false);
+  });
+});
+
+describe("usage tracking", () => {
+  it("records usage entries", async () => {
+    const env = createMockEnv();
+    const today = new Date().toISOString().slice(0, 10);
+    await recordUsage(env, "gmail_check", 100, 50);
+    await recordUsage(env, "analyze_email", 200, 80);
+
+    const entries = await getDailyUsage(env, today);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].job).toBe("gmail_check");
+    expect(entries[0].inputTokens).toBe(100);
+    expect(entries[1].job).toBe("analyze_email");
+  });
+
+  it("returns empty array for date with no usage", async () => {
+    const env = createMockEnv();
+    const entries = await getDailyUsage(env, "2020-01-01");
+    expect(entries).toEqual([]);
+  });
+});

--- a/cf-worker/tsconfig.json
+++ b/cf-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/cf-worker/vitest.config.ts
+++ b/cf-worker/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Provide placeholder values for secrets in tests
+          bindings: {
+            ANTHROPIC_API_KEY: "test-anthropic-key",
+            NOTION_TOKEN: "test-notion-token",
+            NOTION_TASKS_DB_ID: "test-db-id",
+            TELEGRAM_BOT_TOKEN: "test-bot-token",
+            TELEGRAM_CHAT_ID: "test-chat-id",
+            GOOGLE_CLIENT_ID: "test-client-id",
+            GOOGLE_CLIENT_SECRET: "test-client-secret",
+            GOOGLE_REFRESH_TOKEN: "test-refresh-token",
+          },
+        },
+      },
+    },
+  },
+});

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -1,0 +1,38 @@
+name = "ambient-agent"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+[triggers]
+crons = [
+  "50 22 * * *",
+  "55 22 * * *",
+  "57 22 * * *",
+  "58 22 * * *",
+  "0 23 * * *",
+  "5 23 * * *",
+  "10 23 * * *",
+  "0 4 * * *",
+  "0 0 * * 1",
+]
+
+# wrangler kv:namespace create AGENT_KV → replace id below
+[[kv_namespaces]]
+binding = "AGENT_KV"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# wrangler d1 create ambient-agent-db → replace database_id below
+[[d1_databases]]
+binding = "AGENT_DB"
+database_name = "ambient-agent-db"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"
+
+# secrets (set via: wrangler secret put SECRET_NAME)
+# ANTHROPIC_API_KEY
+# NOTION_TOKEN
+# NOTION_TASKS_DB_ID
+# TELEGRAM_BOT_TOKEN
+# TELEGRAM_CHAT_ID
+# GOOGLE_CLIENT_ID
+# GOOGLE_CLIENT_SECRET
+# GOOGLE_REFRESH_TOKEN

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -5,15 +5,10 @@ compatibility_flags = ["nodejs_compat"]
 
 [triggers]
 crons = [
-  "50 22 * * *",
-  "55 22 * * *",
-  "57 22 * * *",
-  "58 22 * * *",
-  "0 23 * * *",
-  "5 23 * * *",
-  "10 23 * * *",
-  "0 4 * * *",
-  "0 0 * * 1",
+  "50 22 * * *",  # 07:50 JST: morning_prep (learn→gmail→calendar→escalation)
+  "0 23 * * *",   # 08:00 JST: morning_briefing (briefing→cost→due_soon)
+  "0 4 * * *",    # 13:00 JST: task_reminder
+  "0 0 * * 1",    # 月 09:00 JST: stale_tasks_notice
 ]
 
 [[kv_namespaces]]

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -16,16 +16,14 @@ crons = [
   "0 0 * * 1",
 ]
 
-# wrangler kv:namespace create AGENT_KV → replace id below
 [[kv_namespaces]]
 binding = "AGENT_KV"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
+id = "c00f19dce0fb4fc495e9425608e53283"
 
-# wrangler d1 create ambient-agent-db → replace database_id below
 [[d1_databases]]
 binding = "AGENT_DB"
 database_name = "ambient-agent-db"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "ba5c15ff-8e0e-4b86-b020-f1c4cb5975a3"
 
 # secrets (set via: wrangler secret put SECRET_NAME)
 # ANTHROPIC_API_KEY


### PR DESCRIPTION
closes #10

## 概要

自宅 PC の Docker デーモンから Cloudflare Workers への移行。

## 変更内容

### インフラ
- Cloudflare Workers (無料枠) にデプロイ
- D1 データベース: スレッドマップ・カレンダー同期・処理済みメッセージ管理
- KV Namespace: Telegram オフセット・タスクキャッシュ・ブロックリスト・使用量ログ
- Cron 9個 → 4個に統合（無料枠の上限に対応）

### アーキテクチャ変更

| 旧（Python + Docker） | 新（TypeScript + Cloudflare） |
|---|---|
| APScheduler BlockingScheduler | Workers Cron Triggers |
| Telegram long-polling | Telegram Webhook → POST /webhook |
| `/data/*.json` ファイル | D1 + KV |
| Google OAuth ブラウザフロー | refresh_token を Secret に保存 |

### Cron スケジュール (JST)
- `07:50` — Gmail処理 → カレンダー同期 → 優先度昇格
- `08:00` — 日次ブリーフィング → コストレポート → 期限通知
- `13:00` — タスクリマインダー
- `月 09:00` — 停滞タスク通知

### CI/CD
- `master` マージ + `cf-worker/` 変更時に自動デプロイ
- テスト通過後に `wrangler deploy`

## テスト

84 tests passing

## 動作確認済み

- [x] Telegram `/tasks` コマンド → Notion からタスク取得・返信
- [x] Webhook 疎通確認
- [x] ローカル Docker・cron 停止済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)