### PR TITLE
fix: fmtDue タイムゾーンバグ修正（CI テスト対応）

### DIFF
--- a/cf-worker/src/handlers/task-formatter.ts
+++ b/cf-worker/src/handlers/task-formatter.ts
@@ -32,9 +32,8 @@ export function fmtDue(d: string | null): string {
     return `${prefix}${weekday}曜`;
   }
 
-  const y = due.getFullYear();
-  const m = String(due.getMonth() + 1).padStart(2, "0");
-  const day = String(due.getDate()).padStart(2, "0");
+  // 文字列から直接パースしてタイムゾーンズレを防ぐ
+  const [y, m, day] = d.slice(0, 10).split("-").map(Number);
   return `${y}年${m}月${day}日`;
 }
 


### PR DESCRIPTION
## 問題

GitHub Actions（UTC 環境）で `fmtDue("2030-12-25")` が `2030年12月24日` を返す。

`new Date("2030-12-25T00:00:00+09:00").getDate()` が UTC では 24 を返すため。

## 修正

日付フォーマット時に `Date` オブジェクトを使わず、入力文字列 `"YYYY-MM-DD"` を直接パースするよう変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)