### PR TITLE
feat: GMAIL_ACCOUNT_INDEX で Gmail の u/N を設定可能にする

### DIFF
--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -88,17 +88,18 @@ export async function getMessage(env: Env, msgId: string): Promise<GmailMessage>
   return resp.json<GmailMessage>();
 }
 
-export function parseMessage(msg: GmailMessage): { subject: string; body: string; senderEmail: string; threadId: string; gmailUrl: string } {
+export function parseMessage(msg: GmailMessage, env?: Env): { subject: string; body: string; senderEmail: string; threadId: string; gmailUrl: string } {
   const headers = parseHeaders(msg.payload);
   const subject = headers["Subject"] ?? "(件名なし)";
   const body = extractBody(msg.payload);
   const senderEmail = extractEmail(headers["From"] ?? "");
   const threadId = msg.threadId ?? "";
 
+  const accountIndex = env?.GMAIL_ACCOUNT_INDEX ?? "0";
   const messageIdHeader = headers["Message-ID"] ?? "";
   const gmailUrl = messageIdHeader
-    ? `https://mail.google.com/mail/u/0/#search/rfc822msgid:${encodeURIComponent(messageIdHeader)}`
-    : `https://mail.google.com/mail/u/0/#all/${threadId}`;
+    ? `https://mail.google.com/mail/u/${accountIndex}/#search/rfc822msgid:${encodeURIComponent(messageIdHeader)}`
+    : `https://mail.google.com/mail/u/${accountIndex}/#all/${threadId}`;
 
   return { subject, body, senderEmail, threadId, gmailUrl };
 }

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -40,7 +40,7 @@ export async function checkGmail(env: Env): Promise<void> {
       continue;
     }
 
-    const { subject, body, senderEmail, threadId, gmailUrl } = parseMessage(msg);
+    const { subject, body, senderEmail, threadId, gmailUrl } = parseMessage(msg, env);
 
     if (noTaskSenders.has(senderEmail)) {
       await archiveMessage(env, meta.id);

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -15,6 +15,7 @@ export interface Env {
   TASK_REMINDER_HOURS?: string;
   COST_REPORT_HOUR?: string;
   GMAIL_TASK_LABEL?: string;
+  GMAIL_ACCOUNT_INDEX?: string;
 }
 
 export interface Task {

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -29,3 +29,6 @@ database_id = "ba5c15ff-8e0e-4b86-b020-f1c4cb5975a3"
 # GOOGLE_CLIENT_ID
 # GOOGLE_CLIENT_SECRET
 # GOOGLE_REFRESH_TOKEN
+
+# optional vars (set via wrangler.toml [vars] or secret)
+# GMAIL_ACCOUNT_INDEX=0  # Gmail の u/N のN（複数アカウント時に変更）


### PR DESCRIPTION
## Summary

- `GMAIL_ACCOUNT_INDEX` 環境変数を追加（デフォルト `0`）
- Gmail 通知リンクの `u/0` をこの値で差し替えるよう変更
- 複数 Google アカウントを使用している場合に対応

## 設定方法

```bash
# Cloudflare Workers に設定する場合
wrangler secret put GMAIL_ACCOUNT_INDEX
# または wrangler.toml の [vars] に追記
```

## Test plan

- [x] 全テストパス（84 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)