### PR TITLE
週次リファクタリング 2026-04-27

### DIFF
--- a/cf-worker/src/handlers/task-formatter.ts
+++ b/cf-worker/src/handlers/task-formatter.ts
@@ -1,5 +1,7 @@
 import type { Task } from "../types.js";
 
+const TASK_APP_URL = "https://todo.eh6gac4.work";
+
 const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
 const PRIORITY_LABELS: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
 const STATUS_ORDER: Record<string, number> = { 未着手: 0, 進行中: 1, 確認中: 2, 一時中断: 3 };
@@ -66,9 +68,9 @@ export function formatTaskList(tasks: Task[], numbered = false): string {
     const due = t.due ? `（${fmtDue(t.due)}）` : "";
     const icon = PRIORITY_LABELS[t.priority] ?? "";
     const prefix = numbered ? `${i + 1}. ` : "• ";
-    const titleText = t.title.replaceAll("]", "\\]");
-    const appUrl = t.pageId ? `https://todo.eh6gac4.work/?task=${t.pageId}` : "";
-    const titleLink = appUrl ? `[${titleText}](${appUrl})` : t.title;
+    const titleLink = t.pageId
+      ? `[${t.title.replaceAll("[", "\\[").replaceAll("]", "\\]")}](${TASK_APP_URL}/?task=${t.pageId})`
+      : t.title;
     lines.push(`${prefix}${icon} ${titleLink}${due}`);
   }
   return lines.join("\n");

--- a/cf-worker/test/unit/handlers/task-formatter.test.ts
+++ b/cf-worker/test/unit/handlers/task-formatter.test.ts
@@ -101,6 +101,6 @@ describe("formatTaskList", () => {
       { title: "タスク[1]", due: null, priority: "medium", status: "未着手", lastEdited: null, url: "https://notion.so/p", pageId: "abc123" },
     ];
     const result = formatTaskList(tasks);
-    expect(result).toContain("[タスク[1\\]](https://todo.eh6gac4.work/?task=abc123)");
+    expect(result).toContain("[タスク\\[1\\]](https://todo.eh6gac4.work/?task=abc123)");
   });
 });


### PR DESCRIPTION
## サマリー
以下の3点を修正しました：

1. **URLを定数化**: `https://todo.eh6gac4.work` を `TASK_APP_URL` 定数として先頭に定義（ハードコードの重複を排除）
2. **`replaceAll` を条件の中に移動**: `pageId` が空の場合は不要な文字列処理を実行しない（効率化）
3. **`[` のエスケープ追加**: Telegram MarkdownV2 仕様では `[` もエスケープが必要なため `replaceAll("[", "\\[")` を追加し、テストも更新

全13テストパス済みです。

## 変更ファイル
- `cf-worker/src/handlers/task-formatter.ts`
- `cf-worker/test/unit/handlers/task-formatter.test.ts`