### PR TITLE
feat: Gmail本文をNotionタスクページに貼り付け

### DIFF
--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -9,6 +9,37 @@ const STATUS_IN_PROGRESS_GROUP = ["進行中", "確認中", "一時中断"];
 const STATUS_DONE = "完了";
 const STATUS_CANCELLED = "中止";
 
+const EMAIL_BODY_MAX_CHARS = 10000;
+const NOTION_RICH_TEXT_MAX = 2000;
+
+function buildEmailBodyBlocks(bodyText: string, headingLabel: string): Array<Record<string, unknown>> {
+  const trimmed = bodyText.trim();
+  if (!trimmed) return [];
+
+  const truncated = trimmed.length > EMAIL_BODY_MAX_CHARS
+    ? trimmed.slice(0, EMAIL_BODY_MAX_CHARS) + "\n\n…(以下省略)"
+    : trimmed;
+
+  const chunks: string[] = [];
+  for (let i = 0; i < truncated.length; i += NOTION_RICH_TEXT_MAX) {
+    chunks.push(truncated.slice(i, i + NOTION_RICH_TEXT_MAX));
+  }
+
+  return [
+    { object: "block", type: "divider", divider: {} },
+    {
+      object: "block",
+      type: "heading_3",
+      heading_3: { rich_text: [{ type: "text", text: { content: headingLabel } }] },
+    },
+    ...chunks.map((chunk) => ({
+      object: "block",
+      type: "paragraph",
+      paragraph: { rich_text: [{ type: "text", text: { content: chunk } }] },
+    })),
+  ];
+}
+
 function headers(token: string): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,
@@ -84,7 +115,7 @@ function parseTaskPage(page: Record<string, unknown>): Task {
   };
 }
 
-export async function addTask(env: Env, task: TaskInput, checklist?: string[]): Promise<string | null> {
+export async function addTask(env: Env, task: TaskInput, checklist?: string[], bodyText?: string): Promise<string | null> {
   const properties: Record<string, unknown> = {
     "タイトル": { title: [{ text: { content: task.title } }] },
     Status: { status: { name: STATUS_PENDING } },
@@ -110,15 +141,18 @@ export async function addTask(env: Env, task: TaskInput, checklist?: string[]): 
     properties,
   };
 
-  if (checklist?.length) {
-    body.children = checklist.map((item) => ({
-      object: "block",
-      type: "to_do",
-      to_do: {
-        rich_text: [{ type: "text", text: { content: item } }],
-        checked: false,
-      },
-    }));
+  const checklistBlocks = (checklist ?? []).map((item) => ({
+    object: "block",
+    type: "to_do",
+    to_do: {
+      rich_text: [{ type: "text", text: { content: item } }],
+      checked: false,
+    },
+  }));
+  const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 メール本文");
+  const children = [...checklistBlocks, ...bodyBlocks];
+  if (children.length) {
+    body.children = children;
   }
 
   const resp = await fetch(`${NOTION_API}/pages`, {
@@ -219,6 +253,7 @@ export async function updateTaskFromReply(
   checklist: string[],
   priority: string,
   due: string | null,
+  bodyText?: string,
 ): Promise<void> {
   const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
 
@@ -254,20 +289,22 @@ export async function updateTaskFromReply(
     });
   }
 
-  if (checklist.length) {
+  const checklistBlocks = checklist.map((item) => ({
+    object: "block",
+    type: "to_do",
+    to_do: {
+      rich_text: [{ type: "text", text: { content: item } }],
+      checked: false,
+    },
+  }));
+  const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 返信メール");
+  const appendChildren = [...checklistBlocks, ...bodyBlocks];
+
+  if (appendChildren.length) {
     await fetch(`${NOTION_API}/blocks/${pageId}/children`, {
       method: "PATCH",
       headers: headers(env.NOTION_TOKEN),
-      body: JSON.stringify({
-        children: checklist.map((item) => ({
-          object: "block",
-          type: "to_do",
-          to_do: {
-            rich_text: [{ type: "text", text: { content: item } }],
-            checked: false,
-          },
-        })),
-      }),
+      body: JSON.stringify({ children: appendChildren }),
     });
   }
 }

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -62,7 +62,7 @@ export async function checkGmail(env: Env): Promise<void> {
       const existingPageId = await getThreadMapEntry(env, threadId);
 
       if (existingPageId) {
-        await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null);
+        await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null, body);
         if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
         taskLines.push(
           `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
@@ -72,6 +72,7 @@ export async function checkGmail(env: Env): Promise<void> {
           env,
           { title: subject, due: dues[0] ?? null, priority: best.priority, source: "Gmail", sourceUrl: gmailUrl },
           checklist,
+          body,
         );
         if (pageId) {
           if (threadId) await setThreadMapEntry(env, threadId, pageId);

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -41,6 +41,65 @@ describe("addTask", () => {
     expect(body.children[0].type).toBe("to_do");
     expect(body.children[0].to_do.rich_text[0].text.content).toBe("項目1");
   });
+
+  it("appends email body blocks after checklist when bodyText provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "メール本文付き" }, ["項目1"], "これはメール本文です。");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.children).toHaveLength(4);
+    expect(body.children[0].type).toBe("to_do");
+    expect(body.children[1].type).toBe("divider");
+    expect(body.children[2].type).toBe("heading_3");
+    expect(body.children[2].heading_3.rich_text[0].text.content).toBe("📧 メール本文");
+    expect(body.children[3].type).toBe("paragraph");
+    expect(body.children[3].paragraph.rich_text[0].text.content).toBe("これはメール本文です。");
+  });
+
+  it("splits long email body into multiple paragraph blocks of 2000 chars each", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const longBody = "あ".repeat(4500);
+    await addTask(env, { title: "長文メール" }, [], longBody);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const paragraphs = body.children.filter((b: { type: string }) => b.type === "paragraph");
+    expect(paragraphs).toHaveLength(3);
+    expect(paragraphs[0].paragraph.rich_text[0].text.content.length).toBe(2000);
+    expect(paragraphs[1].paragraph.rich_text[0].text.content.length).toBe(2000);
+    expect(paragraphs[2].paragraph.rich_text[0].text.content.length).toBe(500);
+  });
+
+  it("truncates email body over 10000 chars with notice", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hugeBody = "x".repeat(15000);
+    await addTask(env, { title: "超長文" }, [], hugeBody);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const paragraphs = body.children.filter((b: { type: string }) => b.type === "paragraph");
+    const lastChunk = paragraphs[paragraphs.length - 1].paragraph.rich_text[0].text.content;
+    expect(lastChunk).toContain("…(以下省略)");
+  });
+
+  it("does not append body blocks when bodyText is empty", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "本文なし" }, ["項目1"], "");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.children).toHaveLength(1);
+    expect(body.children[0].type).toBe("to_do");
+  });
 });
 
 describe("getOpenTasks", () => {

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -74,6 +74,7 @@ describe("checkGmail", () => {
       env,
       expect.objectContaining({ title: "プロジェクトの進捗確認", source: "Gmail" }),
       ["進捗を報告する"],
+      "内容",
     );
   });
 
@@ -106,6 +107,7 @@ describe("checkGmail", () => {
       ["追加確認を実施する"],
       "medium",
       null,
+      "返信内容",
     );
     expect(addTask).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- SourceURL の Gmail Web UI 検索リンクは一発で本文を開けず不便だったため、Notion タスクページに本文を直接埋め込むように変更
- to_do チェックリストの下に divider → "📧 メール本文" 見出し → 本文段落の順で追加
- 同一スレッドへの返信メール（`updateTaskFromReply` 経路）でも "📧 返信メール" ヘッダ付きで追記
- 10,000 字でトリム（超過時は末尾に `…(以下省略)`）、Notion API の rich_text 2000 字制限に合わせて段落を分割
- 本文空（HTML-only メール等）のときは何も追記せず現状動作を維持

## Test plan
- [x] `npm test` が通る（91 件パス、新規 4 件追加）
- [ ] `npx wrangler deploy` でデプロイ後、未読メール受信時に Notion ページに本文が追加されることを確認
- [ ] 同一スレッドの返信メールが届いたとき、既存ページに "📧 返信メール" 付きで追記されることを確認
- [ ] HTML-only メール（マーケ系）で本文ブロックが追加されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)