### PR TITLE
feat: 写真からタスク抽出時に画像を Notion ページに添付する

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | `/unblock <メール>` | 送信者のブロックを解除 |
 | URL 送信 | ページ内容を取得してタスクを抽出し Notion に登録 |
 | テキスト・転送メッセージ送信 | Claude でタスク抽出して Notion に登録 |
-| 画像送信 | Claude Vision でタスク抽出して Notion に登録 |
+| 画像送信 | Claude Vision でタスク抽出 + 画像を Notion ページに添付 |
 
 ## Notion DB 必須プロパティ
 

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -12,6 +12,23 @@ const STATUS_CANCELLED = "中止";
 const EMAIL_BODY_MAX_CHARS = 10000;
 const NOTION_RICH_TEXT_MAX = 2000;
 
+function buildImageBlocks(uploadId: string | undefined): Array<Record<string, unknown>> {
+  if (!uploadId) return [];
+  return [
+    { object: "block", type: "divider", divider: {} },
+    {
+      object: "block",
+      type: "heading_3",
+      heading_3: { rich_text: [{ type: "text", text: { content: "📷 元画像" } }] },
+    },
+    {
+      object: "block",
+      type: "image",
+      image: { type: "file_upload", file_upload: { id: uploadId } },
+    },
+  ];
+}
+
 function buildEmailBodyBlocks(bodyText: string, headingLabel: string): Array<Record<string, unknown>> {
   const trimmed = bodyText.trim();
   if (!trimmed) return [];
@@ -115,7 +132,51 @@ function parseTaskPage(page: Record<string, unknown>): Task {
   };
 }
 
-export async function addTask(env: Env, task: TaskInput, checklist?: string[], bodyText?: string): Promise<string | null> {
+export async function uploadImageToNotion(
+  env: Env,
+  imageData: ArrayBuffer,
+  mediaType: string,
+  filename: string,
+): Promise<string | null> {
+  const MAX_BYTES = 20 * 1024 * 1024;
+  if (imageData.byteLength > MAX_BYTES) return null;
+
+  try {
+    const createResp = await fetch(`${NOTION_API}/file_uploads`, {
+      method: "POST",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({}),
+    });
+    if (!createResp.ok) return null;
+    const created = await createResp.json<{ id: string; upload_url: string }>();
+    if (!created.id || !created.upload_url) return null;
+
+    const form = new FormData();
+    form.append("file", new Blob([imageData], { type: mediaType }), filename);
+
+    const sendResp = await fetch(created.upload_url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.NOTION_TOKEN}`,
+        "Notion-Version": NOTION_VERSION,
+      },
+      body: form,
+    });
+    if (!sendResp.ok) return null;
+
+    return created.id;
+  } catch {
+    return null;
+  }
+}
+
+export async function addTask(
+  env: Env,
+  task: TaskInput,
+  checklist?: string[],
+  bodyText?: string,
+  imageUploadId?: string,
+): Promise<string | null> {
   const properties: Record<string, unknown> = {
     "タイトル": { title: [{ text: { content: task.title } }] },
     Status: { status: { name: STATUS_PENDING } },
@@ -150,7 +211,8 @@ export async function addTask(env: Env, task: TaskInput, checklist?: string[], b
     },
   }));
   const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 メール本文");
-  const children = [...checklistBlocks, ...bodyBlocks];
+  const imageBlocks = buildImageBlocks(imageUploadId);
+  const children = [...checklistBlocks, ...bodyBlocks, ...imageBlocks];
   if (children.length) {
     body.children = children;
   }

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types.js";
 import { sendMessage, getFileUrl } from "../clients/telegram.js";
-import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue } from "../clients/notion.js";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, uploadImageToNotion } from "../clients/notion.js";
 import { extractTasksFromText, extractTasksFromUrlContent, extractTasksFromImage } from "../clients/anthropic.js";
 import { getSenderForTask } from "../storage/d1.js";
 import { getTaskCache, setTaskCache, getNoTaskSenders, addNoTaskSender, removeNoTaskSender } from "../storage/kv.js";
@@ -208,12 +208,17 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
 
   const ext = fileUrl.split(".").pop()?.toLowerCase() ?? "jpg";
   const mediaType = ({ jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif", webp: "image/webp" } as Record<string, string>)[ext] ?? "image/jpeg";
+  const imageData = await imgResp.arrayBuffer();
 
   await sendMessage(env, "⏳ 画像からタスクを抽出中...");
-  const tasks = await extractTasksFromImage(env, await imgResp.arrayBuffer(), mediaType);
+  const [tasks, uploadId] = await Promise.all([
+    extractTasksFromImage(env, imageData, mediaType),
+    uploadImageToNotion(env, imageData, mediaType, `telegram-${largest.file_id}.${ext}`),
+  ]);
   if (tasks.length) {
-    for (const task of tasks) {
-      await addTask(env, { ...task, source: "Telegram" });
+    for (let i = 0; i < tasks.length; i++) {
+      const attachId = i === 0 ? uploadId ?? undefined : undefined;
+      await addTask(env, { ...tasks[i], source: "Telegram" }, undefined, undefined, attachId);
     }
     await sendMessage(env, "✅ タスクを登録しました\n\n" + tasks.map((t) => `• ${t.title}`).join("\n"));
   } else {

--- a/cf-worker/test/fixtures/telegram-updates.json
+++ b/cf-worker/test/fixtures/telegram-updates.json
@@ -54,5 +54,16 @@
       "chat": { "id": 999999999 },
       "text": "/tasks"
     }
+  },
+  "photoMessage": {
+    "update_id": 1008,
+    "message": {
+      "message_id": 8,
+      "chat": { "id": 123456789 },
+      "photo": [
+        { "file_id": "photo-small", "file_size": 1000 },
+        { "file_id": "photo-large", "file_size": 50000 }
+      ]
+    }
   }
 }

--- a/cf-worker/test/integration/telegram-webhook.test.ts
+++ b/cf-worker/test/integration/telegram-webhook.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../src/clients/notion.js", () => ({
   completeTask: vi.fn().mockResolvedValue(undefined),
   cancelTask: vi.fn().mockResolvedValue(undefined),
   updateTaskDue: vi.fn().mockResolvedValue(undefined),
+  uploadImageToNotion: vi.fn().mockResolvedValue("upload-id-test"),
 }));
 
 vi.mock("../../src/clients/telegram.js", () => ({
@@ -110,5 +111,46 @@ describe("Telegram webhook E2E", () => {
 
     const resp = await worker.fetch(webhookRequest(telegramFixtures.addCommand), env);
     expect(resp.status).toBe(200);
+  });
+
+  it("photo message uploads image to Notion and attaches to first task", async () => {
+    const env = createMockEnv({ OPERATING_START_HOUR: "0", OPERATING_END_HOUR: "24" });
+    const { addTask, uploadImageToNotion } = await import("../../src/clients/notion.js");
+    const { extractTasksFromImage } = await import("../../src/clients/anthropic.js");
+    const { getFileUrl } = await import("../../src/clients/telegram.js");
+
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-new");
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue("https://api.telegram.org/file/bottoken/photos/file_5.jpg");
+    (extractTasksFromImage as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "領収書を経費申請", due: null, priority: "medium" },
+      { title: "金額を確認", due: null, priority: "low" },
+    ]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new Uint8Array([0xff, 0xd8, 0xff]).buffer, { status: 200 })));
+
+    const resp = await worker.fetch(webhookRequest(telegramFixtures.photoMessage), env);
+    expect(resp.status).toBe(200);
+
+    expect(uploadImageToNotion).toHaveBeenCalledTimes(1);
+    const uploadArgs = (uploadImageToNotion as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(uploadArgs[2]).toBe("image/jpeg");
+
+    expect(addTask).toHaveBeenCalledTimes(2);
+    const firstCall = (addTask as ReturnType<typeof vi.fn>).mock.calls[0];
+    const secondCall = (addTask as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(firstCall[4]).toBe("upload-id-test");
+    expect(secondCall[4]).toBeUndefined();
+  });
+
+  it("photo message picks the largest photo by file_size", async () => {
+    const env = createMockEnv({ OPERATING_START_HOUR: "0", OPERATING_END_HOUR: "24" });
+    const { extractTasksFromImage } = await import("../../src/clients/anthropic.js");
+    const { getFileUrl } = await import("../../src/clients/telegram.js");
+
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue("https://api.telegram.org/file/bottoken/photos/file_5.jpg");
+    (extractTasksFromImage as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new Uint8Array([0xff]).buffer, { status: 200 })));
+
+    await worker.fetch(webhookRequest(telegramFixtures.photoMessage), env);
+    expect(getFileUrl).toHaveBeenCalledWith(env, "photo-large");
   });
 });

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks } from "../../../src/clients/notion.js";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, uploadImageToNotion } from "../../../src/clients/notion.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import notionFixtures from "../../fixtures/notion-tasks.json" assert { type: "json" };
 
@@ -99,6 +99,97 @@ describe("addTask", () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.children).toHaveLength(1);
     expect(body.children[0].type).toBe("to_do");
+  });
+
+  it("appends image block when imageUploadId provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "画像付き" }, undefined, undefined, "upload-id-123");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.children).toHaveLength(3);
+    expect(body.children[0].type).toBe("divider");
+    expect(body.children[1].type).toBe("heading_3");
+    expect(body.children[1].heading_3.rich_text[0].text.content).toBe("📷 元画像");
+    expect(body.children[2].type).toBe("image");
+    expect(body.children[2].image.file_upload.id).toBe("upload-id-123");
+  });
+
+  it("does not append image block when imageUploadId is undefined", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "画像なし" }, undefined, undefined, undefined);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.children).toBeUndefined();
+  });
+});
+
+describe("uploadImageToNotion", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a file_upload, sends bytes, and returns the upload id", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "upload-id-abc", upload_url: "https://api.notion.com/v1/file_uploads/upload-id-abc/send" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "uploaded" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const bytes = new Uint8Array([1, 2, 3, 4]).buffer;
+    const id = await uploadImageToNotion(env, bytes, "image/jpeg", "test.jpg");
+
+    expect(id).toBe("upload-id-abc");
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.notion.com/v1/file_uploads");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://api.notion.com/v1/file_uploads/upload-id-abc/send");
+    const sendOpts = fetchMock.mock.calls[1][1] as { method: string; body: FormData; headers: Record<string, string> };
+    expect(sendOpts.method).toBe("POST");
+    expect(sendOpts.body).toBeInstanceOf(FormData);
+    expect(sendOpts.headers["Authorization"]).toBe("Bearer test-notion-token");
+    expect(sendOpts.headers["Notion-Version"]).toBeDefined();
+  });
+
+  it("returns null when create endpoint fails", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(new Response("err", { status: 500 })));
+
+    const id = await uploadImageToNotion(env, new Uint8Array([1]).buffer, "image/jpeg", "test.jpg");
+    expect(id).toBeNull();
+  });
+
+  it("returns null when send endpoint fails", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "u1", upload_url: "https://x" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response("err", { status: 500 })),
+    );
+
+    const id = await uploadImageToNotion(env, new Uint8Array([1]).buffer, "image/jpeg", "test.jpg");
+    expect(id).toBeNull();
+  });
+
+  it("returns null when image exceeds 20MB", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const huge = new Uint8Array(21 * 1024 * 1024).buffer;
+    const id = await uploadImageToNotion(env, huge, "image/jpeg", "huge.jpg");
+    expect(id).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on network error", async () => {
+    const env = createMockEnv();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+
+    const id = await uploadImageToNotion(env, new Uint8Array([1]).buffer, "image/jpeg", "test.jpg");
+    expect(id).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Telegram に送られた写真から Claude Vision でタスクを抽出する既存機能に対し、抽出元の写真自体も Notion タスクページ本体に埋め込む
- Notion File Upload API（2025年公開）を使うため Cloudflare R2 等の追加インフラは不要
- 複数タスクが1枚の写真から抽出された場合は最初のタスクにのみ画像を添付（Notion `file_upload` は1ブロックでしか参照できないため）
- アップロード失敗時はタスク作成は継続（既存挙動維持）

## 実装

- `cf-worker/src/clients/notion.ts`
  - `uploadImageToNotion()` — Notion File Upload API への2段階アップロード
  - `buildImageBlocks()` — divider + heading_3「📷 元画像」+ image block
  - `addTask()` の引数に `imageUploadId` を追加
- `cf-worker/src/handlers/telegram.ts:handlePhoto`
  - 画像取得→ `Promise.all` で Claude 抽出と Notion アップロードを並列実行
  - 1件目のタスクのみ `imageUploadId` を渡す
- `README.md` 「画像送信」行の説明を更新

## Test plan

- [x] `cf-worker/test/unit/clients/notion.test.ts` — `uploadImageToNotion` の単体テスト追加（成功・create失敗・send失敗・20MB超過・network error / `addTask` の image block 追加検証）
- [x] `cf-worker/test/integration/telegram-webhook.test.ts` — photo メッセージの統合テスト追加（最大サイズ選択 / 1件目に upload id 付与 / 2件目には付与しない）
- [x] `npm test` — 9件の新規テストすべて pass、既存テストの failure はすべて pre-existing（master 上でも失敗する `fmtDue` のタイムゾーンテスト）
- [ ] デプロイ後に Telegram で実際に写真を送り、Notion タスクページに画像が埋め込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)