### PR TITLE
feat: メール処理を毎時のサイレント処理＋朝のサマリ送信に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,24 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 
 | 時刻 (JST) | ジョブ | 内容 |
 |---|---|---|
-| 07:50 | morning_prep | ①ブロックリスト学習 → ②Gmail処理 → ③カレンダー同期 → ④優先度昇格 |
-| 08:00 | morning_briefing | ①日次ブリーフィング → ②APIコストレポート → ③期限間近通知 |
+| 07:30〜21:30 毎時 | hourly_gmail | Gmail 未読を少しずつサイレント処理（通知せず KV に蓄積） |
+| 07:50 | morning_prep | ①ブロックリスト学習 → ②カレンダー同期 → ③優先度昇格 |
+| 08:00 | morning_briefing | ①日次ブリーフィング → ②APIコストレポート → ③期限間近通知 → ④メール処理サマリ |
 | 13:00 | task_reminder | 未着手タスク一覧を Telegram に送信 |
 | 月 09:00 | stale_tasks | 14日以上未更新タスクを通知 |
 
+**hourly_gmail の詳細:**
+- 未読メールを要約・タスク抽出し Notion に登録（返信スレッドは既存タスクを更新）
+- Telegram 通知はせず、結果を `email_digest:pending` (KV) に追記
+- Workers の subrequest 上限（無料プラン 50/呼び出し）に達したら break、未処理分は次回 cron に持ち越し
+- 個別メール処理エラーは log して続行
+
 **morning_prep の詳細:**
-- Gmail 未読メールを要約・タスク抽出し Notion に登録（返信スレッドは既存タスクを更新）
 - 完了済みタスクのカレンダーイベントを削除、未着手タスクを Calendar に登録
 - 期限3日以内の medium タスクを high に昇格
+
+**morning_briefing の詳細:**
+- 直近 24 時間に hourly_gmail が処理したメールをまとめて1通の「📧 メール処理サマリ」として Telegram 送信
 
 ## Telegram コマンド
 

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -3,7 +3,7 @@ import { getTodaysEvents } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
 import { summarizeDay } from "../clients/anthropic.js";
 import { sendMessage } from "../clients/telegram.js";
-import { getDailyUsage } from "../storage/kv.js";
+import { getDailyUsage, takeEmailDigest } from "../storage/kv.js";
 
 const PRICE_INPUT_PER_M = 0.8;
 const PRICE_OUTPUT_PER_M = 4.0;
@@ -74,4 +74,14 @@ export async function sendCostReport(env: Env): Promise<void> {
   ];
 
   await sendMessage(env, lines.join("\n"));
+}
+
+export async function sendEmailDigest(env: Env): Promise<void> {
+  const { taskLines, archivedLines } = await takeEmailDigest(env);
+  if (!taskLines.length && !archivedLines.length) return;
+
+  const sections: string[] = [];
+  if (taskLines.length) sections.push("✅ *タスク登録*\n" + taskLines.join("\n"));
+  if (archivedLines.length) sections.push("📦 *アーカイブ済み*\n" + archivedLines.join("\n"));
+  await sendMessage(env, "*📧 メール処理サマリ*\n\n" + sections.join("\n\n"));
 }

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -14,9 +14,18 @@ import {
   markProcessed,
   cleanOldProcessed,
 } from "../storage/d1.js";
-import { getNoTaskSenders, addNoTaskSender } from "../storage/kv.js";
+import { getNoTaskSenders, addNoTaskSender, appendEmailDigest } from "../storage/kv.js";
 
-export async function checkGmail(env: Env): Promise<void> {
+function isSubrequestLimitError(err: unknown): boolean {
+  return String(err).includes("Too many subrequests");
+}
+
+export interface CheckGmailOptions {
+  /** When true, accumulate results to KV instead of sending Telegram immediately. */
+  silent?: boolean;
+}
+
+export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Promise<void> {
   await cleanOldProcessed(env);
 
   const messages = await listAllMessages(env);
@@ -30,68 +39,81 @@ export async function checkGmail(env: Env): Promise<void> {
   const archivedLines: string[] = [];
 
   for (const meta of messages) {
-    if (await isProcessed(env, meta.id)) continue;
+    try {
+      if (await isProcessed(env, meta.id)) continue;
 
-    const msg = await getMessage(env, meta.id);
+      const msg = await getMessage(env, meta.id);
 
-    if (isCalendarInvite(msg.payload)) {
-      await archiveMessage(env, meta.id);
-      await markProcessed(env, meta.id);
-      continue;
-    }
-
-    const { subject, body, senderEmail, threadId, gmailUrl } = parseMessage(msg, env);
-
-    if (noTaskSenders.has(senderEmail)) {
-      await archiveMessage(env, meta.id);
-      await markProcessed(env, meta.id);
-      continue;
-    }
-
-    const analysis = await analyzeEmail(env, subject, body);
-    const { summary, tasks } = analysis;
-
-    if (tasks.length) {
-      const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
-      const best = tasks.reduce((a, b) =>
-        (priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b,
-      );
-      const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
-      const checklist = tasks.map((t) => t.title);
-
-      const existingPageId = await getThreadMapEntry(env, threadId);
-
-      if (existingPageId) {
-        await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null, body);
-        if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
-        taskLines.push(
-          `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
-        );
-      } else {
-        const pageId = await addTask(
-          env,
-          { title: subject, due: dues[0] ?? null, priority: best.priority, source: "Gmail", sourceUrl: gmailUrl },
-          checklist,
-          body,
-        );
-        if (pageId) {
-          if (threadId) await setThreadMapEntry(env, threadId, pageId);
-          await setSenderForTask(env, pageId, senderEmail);
-          if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
-        }
-        taskLines.push(
-          `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
-        );
+      if (isCalendarInvite(msg.payload)) {
+        await archiveMessage(env, meta.id);
+        await markProcessed(env, meta.id);
+        continue;
       }
-    } else {
-      archivedLines.push(`• *${escapeMd(subject)}*\n  ${escapeMd(summary)}`);
-    }
 
-    await archiveMessage(env, meta.id);
-    await markProcessed(env, meta.id);
+      const { subject, body, senderEmail, threadId, gmailUrl } = parseMessage(msg, env);
+
+      if (noTaskSenders.has(senderEmail)) {
+        await archiveMessage(env, meta.id);
+        await markProcessed(env, meta.id);
+        continue;
+      }
+
+      const analysis = await analyzeEmail(env, subject, body);
+      const { summary, tasks } = analysis;
+
+      if (tasks.length) {
+        const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+        const best = tasks.reduce((a, b) =>
+          (priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b,
+        );
+        const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
+        const checklist = tasks.map((t) => t.title);
+
+        const existingPageId = await getThreadMapEntry(env, threadId);
+
+        if (existingPageId) {
+          await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null, body);
+          if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+          taskLines.push(
+            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+          );
+        } else {
+          const pageId = await addTask(
+            env,
+            { title: subject, due: dues[0] ?? null, priority: best.priority, source: "Gmail", sourceUrl: gmailUrl },
+            checklist,
+            body,
+          );
+          if (pageId) {
+            if (threadId) await setThreadMapEntry(env, threadId, pageId);
+            await setSenderForTask(env, pageId, senderEmail);
+            if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+          }
+          taskLines.push(
+            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+          );
+        }
+      } else {
+        archivedLines.push(`• *${escapeMd(subject)}*\n  ${escapeMd(summary)}`);
+      }
+
+      await archiveMessage(env, meta.id);
+      await markProcessed(env, meta.id);
+    } catch (err) {
+      if (isSubrequestLimitError(err)) {
+        console.warn("checkGmail: subrequest limit hit, deferring remaining messages");
+        break;
+      }
+      console.error(`checkGmail: failed to process message ${meta.id}:`, err);
+    }
   }
 
   if (!taskLines.length && !archivedLines.length) return;
+
+  if (options.silent) {
+    await appendEmailDigest(env, { taskLines, archivedLines });
+    return;
+  }
 
   const sections: string[] = [];
   if (taskLines.length) sections.push("✅ *タスク登録*\n" + taskLines.join("\n"));

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -1,15 +1,18 @@
 import type { Env } from "./types.js";
 import { checkGmail, learnFromCancelled } from "./handlers/gmail.js";
 import { syncCalendar, sendDueSoonNotice, sendTaskReminder } from "./handlers/calendar.js";
-import { sendDailyBriefing, sendCostReport } from "./handlers/briefing.js";
+import { sendDailyBriefing, sendCostReport, sendEmailDigest } from "./handlers/briefing.js";
 import { sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
 import { handleTelegramWebhook } from "./handlers/telegram.js";
 import { sendMessage } from "./clients/telegram.js";
 
-// 無料プランの Cron 上限（5個）に合わせて4つに統合
+// 無料プランの Cron 上限（5個）に合わせて5ジョブに統合
+async function hourlyGmail(env: Env): Promise<void> {
+  await checkGmail(env, { silent: true });
+}
+
 async function morningPrep(env: Env): Promise<void> {
   await learnFromCancelled(env);
-  await checkGmail(env);
   await syncCalendar(env);
   await sendEscalationNotice(env);
 }
@@ -18,11 +21,13 @@ async function morningBriefing(env: Env): Promise<void> {
   await sendDailyBriefing(env);
   await sendCostReport(env);
   await sendDueSoonNotice(env);
+  await sendEmailDigest(env);
 }
 
 const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
-  "50 22 * * *": morningPrep,          // 07:50 JST: learn→gmail→calendar→escalation
-  "0 23 * * *": morningBriefing,       // 08:00 JST: briefing→cost→due_soon
+  "30 22-23,0-12 * * *": hourlyGmail,  // 毎時30分 (JST 07:30-21:30): silent gmail batch
+  "50 22 * * *": morningPrep,          // 07:50 JST: learn→calendar→escalation
+  "0 23 * * *": morningBriefing,       // 08:00 JST: briefing→cost→due_soon→email_digest
   "0 4 * * *": sendTaskReminder,       // 13:00 JST
   "0 0 * * 1": sendStaleTasksNotice,   // 月 09:00 JST
 };

--- a/cf-worker/src/storage/kv.ts
+++ b/cf-worker/src/storage/kv.ts
@@ -45,6 +45,34 @@ export async function removeNoTaskSender(env: Env, email: string): Promise<boole
   return true;
 }
 
+// Email digest (accumulated by hourly checkGmail, sent by morning briefing)
+const EMAIL_DIGEST_KEY = "email_digest:pending";
+
+export interface EmailDigest {
+  taskLines: string[];
+  archivedLines: string[];
+}
+
+export async function appendEmailDigest(env: Env, batch: EmailDigest): Promise<void> {
+  if (!batch.taskLines.length && !batch.archivedLines.length) return;
+  const existing = (await env.AGENT_KV.get<EmailDigest>(EMAIL_DIGEST_KEY, "json")) ?? {
+    taskLines: [],
+    archivedLines: [],
+  };
+  existing.taskLines.push(...batch.taskLines);
+  existing.archivedLines.push(...batch.archivedLines);
+  await env.AGENT_KV.put(EMAIL_DIGEST_KEY, JSON.stringify(existing));
+}
+
+export async function takeEmailDigest(env: Env): Promise<EmailDigest> {
+  const existing = (await env.AGENT_KV.get<EmailDigest>(EMAIL_DIGEST_KEY, "json")) ?? {
+    taskLines: [],
+    archivedLines: [],
+  };
+  await env.AGENT_KV.delete(EMAIL_DIGEST_KEY);
+  return existing;
+}
+
 // Usage tracking
 export async function recordUsage(env: Env, job: string, inputTokens: number, outputTokens: number): Promise<void> {
   const dateStr = new Date().toISOString().slice(0, 10);

--- a/cf-worker/test/integration/scheduled.test.ts
+++ b/cf-worker/test/integration/scheduled.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../src/handlers/calendar.js", () => ({
 vi.mock("../../src/handlers/briefing.js", () => ({
   sendDailyBriefing: vi.fn().mockResolvedValue(undefined),
   sendCostReport: vi.fn().mockResolvedValue(undefined),
+  sendEmailDigest: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../src/handlers/escalation.js", () => ({
@@ -57,27 +58,36 @@ describe("scheduled handler - cron dispatch", () => {
     expect(learnFromCancelled).toHaveBeenCalledWith(env);
   });
 
-  it("50 22 * * * (morning_prep) runs gmail, calendar, escalation", async () => {
+  it("50 22 * * * (morning_prep) runs calendar, escalation (no gmail)", async () => {
     const env = createMockEnv();
     const { checkGmail } = await import("../../src/handlers/gmail.js");
     const { syncCalendar } = await import("../../src/handlers/calendar.js");
     const { sendEscalationNotice } = await import("../../src/handlers/escalation.js");
 
     await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
-    expect(checkGmail).toHaveBeenCalledWith(env);
+    expect(checkGmail).not.toHaveBeenCalled();
     expect(syncCalendar).toHaveBeenCalledWith(env);
     expect(sendEscalationNotice).toHaveBeenCalledWith(env);
   });
 
-  it("0 23 * * * (morning_briefing) runs briefing, cost, due_soon", async () => {
+  it("30 22-23,0-12 * * * (hourly_gmail) runs checkGmail in silent mode", async () => {
     const env = createMockEnv();
-    const { sendDailyBriefing, sendCostReport } = await import("../../src/handlers/briefing.js");
+    const { checkGmail } = await import("../../src/handlers/gmail.js");
+
+    await worker.scheduled(makeScheduledEvent("30 22-23,0-12 * * *"), env);
+    expect(checkGmail).toHaveBeenCalledWith(env, { silent: true });
+  });
+
+  it("0 23 * * * (morning_briefing) runs briefing, cost, due_soon, email_digest", async () => {
+    const env = createMockEnv();
+    const { sendDailyBriefing, sendCostReport, sendEmailDigest } = await import("../../src/handlers/briefing.js");
     const { sendDueSoonNotice } = await import("../../src/handlers/calendar.js");
 
     await worker.scheduled(makeScheduledEvent("0 23 * * *"), env);
     expect(sendDailyBriefing).toHaveBeenCalledWith(env);
     expect(sendCostReport).toHaveBeenCalledWith(env);
     expect(sendDueSoonNotice).toHaveBeenCalledWith(env);
+    expect(sendEmailDigest).toHaveBeenCalledWith(env);
   });
 
   it("dispatches sendStaleTasksNotice for 0 0 * * 1", async () => {
@@ -90,10 +100,10 @@ describe("scheduled handler - cron dispatch", () => {
 
   it("sends error notification to Telegram when job throws", async () => {
     const env = createMockEnv();
-    const { checkGmail } = await import("../../src/handlers/gmail.js");
+    const { syncCalendar } = await import("../../src/handlers/calendar.js");
     const { sendMessage } = await import("../../src/clients/telegram.js");
 
-    (checkGmail as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("API timeout"));
+    (syncCalendar as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("API timeout"));
 
     await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
     expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("エラー"));

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -171,6 +171,96 @@ describe("checkGmail", () => {
     await checkGmail(env);
     expect(sendMessage).not.toHaveBeenCalled();
   });
+
+  it("breaks loop on subrequest limit error and skips Telegram if no work done", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage } = await import("../../../src/clients/gmail-api.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+    const { isProcessed } = await import("../../../src/storage/d1.js");
+
+    (isProcessed as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "msg-a", threadId: "t-a" },
+      { id: "msg-b", threadId: "t-b" },
+    ]);
+    (getMessage as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Too many subrequests by single Worker invocation"));
+
+    await checkGmail(env);
+    // Only first message attempted; loop breaks; no Telegram (nothing accumulated)
+    expect(getMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("continues loop on per-message non-limit errors", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage, isCalendarInvite } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry, isProcessed } = await import("../../../src/storage/d1.js");
+
+    (isCalendarInvite as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (isProcessed as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "msg-bad", threadId: "t-bad" },
+      { id: "msg-good", threadId: "t-good" },
+    ]);
+    (getMessage as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("transient parse error"))
+      .mockResolvedValueOnce(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "ok",
+      body: "本文",
+      senderEmail: "ok@example.com",
+      threadId: "t-good",
+      gmailUrl: "https://mail.google.com/",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "要約",
+      tasks: [{ title: "やる", priority: "medium", due: null }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-good");
+
+    await checkGmail(env);
+    expect(addTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("silent mode accumulates digest to KV and skips Telegram", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage, isCalendarInvite } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry, isProcessed } = await import("../../../src/storage/d1.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (isCalendarInvite as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (isProcessed as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-silent", threadId: "t-silent" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "サイレント件名",
+      body: "本文",
+      senderEmail: "silent@example.com",
+      threadId: "t-silent",
+      gmailUrl: "https://mail.google.com/",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "要約",
+      tasks: [{ title: "サイレントタスク", priority: "medium", due: null }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-silent");
+
+    await checkGmail(env, { silent: true });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    const digest = await env.AGENT_KV.get<{ taskLines: string[]; archivedLines: string[] }>(
+      "email_digest:pending",
+      "json",
+    );
+    expect(digest?.taskLines.length).toBe(1);
+    expect(digest?.taskLines[0]).toContain("サイレント件名");
+  });
 });
 
 describe("learnFromCancelled", () => {

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -5,10 +5,11 @@ compatibility_flags = ["nodejs_compat"]
 
 [triggers]
 crons = [
-  "50 22 * * *",  # 07:50 JST: morning_prep (learn→gmail→calendar→escalation)
-  "0 23 * * *",   # 08:00 JST: morning_briefing (briefing→cost→due_soon)
-  "0 4 * * *",    # 13:00 JST: task_reminder
-  "0 0 * * 1",    # 月 09:00 JST: stale_tasks_notice
+  "30 22-23,0-12 * * *",  # 毎時30分 (JST 07:30-21:30): hourly_gmail (silent batch)
+  "50 22 * * *",          # 07:50 JST: morning_prep (learn→calendar→escalation)
+  "0 23 * * *",           # 08:00 JST: morning_briefing (briefing→cost→due_soon→email_digest)
+  "0 4 * * *",            # 13:00 JST: task_reminder
+  "0 0 * * 1",            # 月 09:00 JST: stale_tasks_notice
 ]
 
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary

今朝の `morning_prep` cron が **Workers Free プランの subrequest 上限（50/呼び出し）** に達して中断 → 完了通知が届かなかった問題への恒久対応。

### 今朝起きた事象（証拠）

- `processed_messages` テーブル: 07:50 JST に 12 件処理 → ~22 件未読のまま残存
- `usage:2026-04-28` (KV): analyze_email 9 件 = 12 - 3（calendar/blocklist 早期 return）
- 手動再実行で `Too many subrequests by single Worker invocation` を再現

事前 6 subrequests + 1メールあたり 5 subrequests × 9 件 = ~51 で 50 を超過。

### 変更内容

- `checkGmail` に `silent` オプションと per-iteration try/catch を追加
  - subrequest 上限エラー時は `break` して未処理分を次回 cron に持ち越し
  - 個別メール処理エラーは `console.error` して `continue`
  - `silent: true` で KV (`email_digest:pending`) に蓄積、Telegram 通知はスキップ
- `hourly_gmail` cron を新設（`30 22-23,0-12 * * *` = JST 07:30〜21:30 毎時30分）
- `morning_prep` から `checkGmail` を外す（hourly 担当に移管）
- `morning_briefing` に `sendEmailDigest` を追加（蓄積分を「📧 メール処理サマリ」として1通送信）

### 新 cron 構成（5本＝無料枠ぴったり）

| 時刻 (JST) | ジョブ | 内容 |
|---|---|---|
| 07:30〜21:30 毎時 | hourly_gmail | サイレント処理→KV 蓄積 |
| 07:50 | morning_prep | learn → calendar → escalation |
| 08:00 | morning_briefing | briefing → cost → due_soon → **email_digest** |
| 13:00 | task_reminder | 未着手タスク一覧 |
| 月 09:00 | stale_tasks | 14日以上未更新タスク通知 |

## Test plan

- [x] `npm test` 全 104 件パス
- [x] 既に master にマージ前のブランチで `wrangler deploy` 済み（subrequest 上限の再現確認に使用）
- [ ] マージ後、明朝 07:30 JST から hourly_gmail が走り、08:00 JST に「📧 メール処理サマリ」が1通届く