### PR TITLE
fix: メール本文の文字化けを修正

### DIFF
--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -31,11 +31,30 @@ function isCalendarInvite(payload: GmailPayload): boolean {
   return (payload.parts ?? []).some(isCalendarInvite);
 }
 
+function extractCharset(payload: GmailPayload): string {
+  const ct = (payload.headers ?? []).find((h) => h.name.toLowerCase() === "content-type")?.value ?? "";
+  const m = ct.match(/charset\s*=\s*"?([^";]+)"?/i);
+  return m ? m[1].trim().toLowerCase() : "utf-8";
+}
+
+function decodeBase64Url(data: string, charset: string): string {
+  const binary = atob(data.replace(/-/g, "+").replace(/_/g, "/"));
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  let decoder: TextDecoder;
+  try {
+    decoder = new TextDecoder(charset);
+  } catch {
+    decoder = new TextDecoder("utf-8");
+  }
+  return decoder.decode(bytes);
+}
+
 function extractBody(payload: GmailPayload): string {
   if (payload.mimeType === "text/plain") {
     const data = payload.body?.data ?? "";
+    if (!data) return "";
     try {
-      return atob(data.replace(/-/g, "+").replace(/_/g, "/"));
+      return decodeBase64Url(data, extractCharset(payload));
     } catch {
       return "";
     }

--- a/cf-worker/test/unit/clients/gmail-api.test.ts
+++ b/cf-worker/test/unit/clients/gmail-api.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseMessage } from "../../../src/clients/gmail-api.js";
+
+function b64url(input: Uint8Array): string {
+  let bin = "";
+  for (const b of input) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function utf8B64Url(text: string): string {
+  return b64url(new TextEncoder().encode(text));
+}
+
+describe("parseMessage body decoding", () => {
+  it("decodes UTF-8 Japanese body via TextDecoder (no mojibake)", () => {
+    const body = "長 俊貴 様\nヤマト運輸をご利用いただきありがとうございます。";
+    const msg = {
+      id: "m1",
+      threadId: "t1",
+      payload: {
+        mimeType: "text/plain",
+        headers: [
+          { name: "Subject", value: "件名サンプル" },
+          { name: "From", value: "Sender <s@example.com>" },
+          { name: "Content-Type", value: 'text/plain; charset="UTF-8"' },
+        ],
+        body: { data: utf8B64Url(body) },
+      },
+    };
+    const parsed = parseMessage(msg as never);
+    expect(parsed.body).toBe(body);
+    expect(parsed.subject).toBe("件名サンプル");
+  });
+
+  it("falls back to UTF-8 when charset header is missing", () => {
+    const body = "テスト本文です";
+    const msg = {
+      id: "m2",
+      threadId: "t2",
+      payload: {
+        mimeType: "text/plain",
+        headers: [
+          { name: "Subject", value: "x" },
+          { name: "From", value: "x@example.com" },
+        ],
+        body: { data: utf8B64Url(body) },
+      },
+    };
+    expect(parseMessage(msg as never).body).toBe(body);
+  });
+
+  it("recurses into multipart and decodes nested text/plain part", () => {
+    const body = "multipart 本文";
+    const msg = {
+      id: "m3",
+      threadId: "t3",
+      payload: {
+        mimeType: "multipart/alternative",
+        headers: [
+          { name: "Subject", value: "multi" },
+          { name: "From", value: "x@example.com" },
+        ],
+        parts: [
+          {
+            mimeType: "text/html",
+            headers: [{ name: "Content-Type", value: "text/html; charset=UTF-8" }],
+            body: { data: utf8B64Url("<p>HTML</p>") },
+          },
+          {
+            mimeType: "text/plain",
+            headers: [{ name: "Content-Type", value: "text/plain; charset=UTF-8" }],
+            body: { data: utf8B64Url(body) },
+          },
+        ],
+      },
+    };
+    expect(parseMessage(msg as never).body).toBe(body);
+  });
+
+  it("falls back to UTF-8 for unsupported charset label", () => {
+    const body = "サポート外 charset でもUTF-8として読む";
+    const msg = {
+      id: "m4",
+      threadId: "t4",
+      payload: {
+        mimeType: "text/plain",
+        headers: [
+          { name: "Subject", value: "x" },
+          { name: "From", value: "x@example.com" },
+          { name: "Content-Type", value: "text/plain; charset=x-unknown-codec" },
+        ],
+        body: { data: utf8B64Url(body) },
+      },
+    };
+    expect(parseMessage(msg as never).body).toBe(body);
+  });
+});


### PR DESCRIPTION
## Summary

Notion 上で Gmail 由来のタスク本文が文字化けしていた問題の修正。

`extractBody` の `atob` はバイナリ文字列（各文字 = 1 バイト）を返すだけで UTF-8 デコードまでしておらず、日本語 UTF-8 バイト列が Latin-1 として Notion に保存されていた。

### 変更内容

- `Content-Type: text/plain; charset=...` ヘッダから charset を抽出
- `Uint8Array` + `TextDecoder` でバイト列を正しくデコード
- 未指定 / 未対応 charset は UTF-8 にフォールバック
- `parseMessage` のユニットテスト 4 件追加（UTF-8 / charset 無し / multipart / 未対応 charset）

## Test plan

- [x] `npm test` 全パス（gmail-api.test.ts 4件含む）
- [ ] マージ後、明朝の hourly_gmail で受信したメール本文が Notion 上で正しく表示される