### PR TITLE
feat: 画像タスクを1件に集約 + 画像を Notion ページに添付

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | `/unblock <メール>` | 送信者のブロックを解除 |
 | URL 送信 | ページ内容を取得してタスクを抽出し Notion に登録 |
 | テキスト・転送メッセージ送信 | Claude でタスク抽出して Notion に登録 |
-| 画像送信 | Claude Vision でタスク抽出して Notion に登録 |
+| 画像送信 | Claude Vision で要約・タスク抽出 → 1タスクにまとめて Notion 登録、複数アクションはチェックリスト化、画像をページ本文に添付 |
 
 ## Notion DB 必須プロパティ
 

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -126,14 +126,64 @@ export async function extractTasksFromUrlContent(env: Env, url: string, content:
   return extractJsonList(text);
 }
 
+function imageToBase64(imageData: ArrayBuffer): string {
+  let bin = "";
+  const bytes = new Uint8Array(imageData);
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
 export async function extractTasksFromImage(env: Env, imageData: ArrayBuffer, mediaType: string): Promise<ExtractedTask[]> {
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(imageData)));
   const userContent = [
-    { type: "image", source: { type: "base64", media_type: mediaType, data: b64 } },
+    { type: "image", source: { type: "base64", media_type: mediaType, data: imageToBase64(imageData) } },
     { type: "text", text: "この画像からアクションが必要なタスクを抽出してください。" },
   ];
   const text = await callClaude(env, "extract_tasks_image", EXTRACT_TASKS_PROMPT, userContent);
   return extractJsonList(text);
+}
+
+const ANALYZE_IMAGE_PROMPT = `あなたは画像からタスクを分析するアシスタントです。
+
+画像（レシート・ホワイトボード・メモ・スクリーンショット等）を読み、要約と実行が必要なタスクを JSON で返してください。
+
+## 出力フォーマット（JSON のみ、説明文不要）
+
+\`\`\`json
+{
+  "summary": "画像の内容を1文で要約（タスクのタイトルとして使う）",
+  "tasks": [
+    {
+      "title": "具体的にやること（簡潔に）",
+      "due": "YYYY-MM-DD または null",
+      "priority": "high | medium | low",
+      "source": "Telegram"
+    }
+  ]
+}
+\`\`\`
+
+## 判断基準
+- summary: 「何の画像か / なぜ撮ったと考えられるか」を1文に。タスク登録時のタイトルになるので具体的に
+- tasks: 関連する一連のアクションは細切れにせず、できるだけ少ない数にまとめる
+- 期日が画像内に明示されていれば due に設定する（不明なら null）
+- 緊急・至急 → high、通常 → medium`;
+
+export async function analyzeImage(env: Env, imageData: ArrayBuffer, mediaType: string): Promise<EmailAnalysis> {
+  const userContent = [
+    { type: "image", source: { type: "base64", media_type: mediaType, data: imageToBase64(imageData) } },
+    { type: "text", text: "この画像を分析してください。" },
+  ];
+  const text = await callClaude(env, "analyze_image", ANALYZE_IMAGE_PROMPT, userContent);
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return { summary: text.trim(), tasks: [] };
+  try {
+    const result = JSON.parse(match[0]) as EmailAnalysis;
+    result.tasks ??= [];
+    result.summary ??= "";
+    return result;
+  } catch {
+    return { summary: text.trim(), tasks: [] };
+  }
 }
 
 export async function summarizeDay(

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -40,6 +40,17 @@ function buildEmailBodyBlocks(bodyText: string, headingLabel: string): Array<Rec
   ];
 }
 
+function buildImageBlocks(uploadId: string | undefined): Array<Record<string, unknown>> {
+  if (!uploadId) return [];
+  return [
+    {
+      object: "block",
+      type: "image",
+      image: { type: "file_upload", file_upload: { id: uploadId } },
+    },
+  ];
+}
+
 function headers(token: string): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,
@@ -115,7 +126,51 @@ function parseTaskPage(page: Record<string, unknown>): Task {
   };
 }
 
-export async function addTask(env: Env, task: TaskInput, checklist?: string[], bodyText?: string): Promise<string | null> {
+export async function uploadImageToNotion(
+  env: Env,
+  imageData: ArrayBuffer,
+  mediaType: string,
+  filename: string,
+): Promise<string | null> {
+  const MAX_BYTES = 20 * 1024 * 1024;
+  if (imageData.byteLength > MAX_BYTES) return null;
+
+  try {
+    const createResp = await fetch(`${NOTION_API}/file_uploads`, {
+      method: "POST",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({}),
+    });
+    if (!createResp.ok) return null;
+    const created = await createResp.json<{ id: string; upload_url: string }>();
+    if (!created.id || !created.upload_url) return null;
+
+    const form = new FormData();
+    form.append("file", new Blob([imageData], { type: mediaType }), filename);
+
+    const sendResp = await fetch(created.upload_url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.NOTION_TOKEN}`,
+        "Notion-Version": NOTION_VERSION,
+      },
+      body: form,
+    });
+    if (!sendResp.ok) return null;
+
+    return created.id;
+  } catch {
+    return null;
+  }
+}
+
+export async function addTask(
+  env: Env,
+  task: TaskInput,
+  checklist?: string[],
+  bodyText?: string,
+  imageUploadId?: string,
+): Promise<string | null> {
   const properties: Record<string, unknown> = {
     "タイトル": { title: [{ text: { content: task.title } }] },
     Status: { status: { name: STATUS_PENDING } },
@@ -150,7 +205,8 @@ export async function addTask(env: Env, task: TaskInput, checklist?: string[], b
     },
   }));
   const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 メール本文");
-  const children = [...checklistBlocks, ...bodyBlocks];
+  const imageBlocks = buildImageBlocks(imageUploadId);
+  const children = [...checklistBlocks, ...bodyBlocks, ...imageBlocks];
   if (children.length) {
     body.children = children;
   }

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types.js";
 import { sendMessage, getFileUrl } from "../clients/telegram.js";
-import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue } from "../clients/notion.js";
-import { extractTasksFromText, extractTasksFromUrlContent, extractTasksFromImage } from "../clients/anthropic.js";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, uploadImageToNotion } from "../clients/notion.js";
+import { extractTasksFromText, extractTasksFromUrlContent, analyzeImage } from "../clients/anthropic.js";
 import { getSenderForTask } from "../storage/d1.js";
 import { getTaskCache, setTaskCache, getNoTaskSenders, addNoTaskSender, removeNoTaskSender } from "../storage/kv.js";
 import { deleteCalendarEventForTask } from "./calendar.js";
@@ -208,17 +208,34 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
 
   const ext = fileUrl.split(".").pop()?.toLowerCase() ?? "jpg";
   const mediaType = ({ jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif", webp: "image/webp" } as Record<string, string>)[ext] ?? "image/jpeg";
+  const imageData = await imgResp.arrayBuffer();
 
   await sendMessage(env, "⏳ 画像からタスクを抽出中...");
-  const tasks = await extractTasksFromImage(env, await imgResp.arrayBuffer(), mediaType);
-  if (tasks.length) {
-    for (const task of tasks) {
-      await addTask(env, { ...task, source: "Telegram" });
-    }
-    await sendMessage(env, "✅ タスクを登録しました\n\n" + tasks.map((t) => `• ${t.title}`).join("\n"));
-  } else {
-    await sendMessage(env, "ℹ️ タスクは見つかりませんでした");
-  }
+  const [{ summary, tasks }, uploadId] = await Promise.all([
+    analyzeImage(env, imageData, mediaType),
+    uploadImageToNotion(env, imageData, mediaType, `telegram-${largest.file_id}.${ext}`),
+  ]);
+
+  const checklist = tasks.map((t) => t.title);
+  const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
+  const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  const best = tasks.length
+    ? tasks.reduce((a, b) => ((priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b))
+    : { priority: "medium" as const };
+  const title = (summary || tasks[0]?.title || "📷 画像メモ").slice(0, 200);
+
+  await addTask(
+    env,
+    { title, due: dues[0] ?? null, priority: best.priority, source: "Telegram" },
+    checklist,
+    undefined,
+    uploadId ?? undefined,
+  );
+
+  const lines = [`✅ タスクを登録しました`, ``, `*${title}*`];
+  if (checklist.length) lines.push(...checklist.map((t) => `• ${t}`));
+  if (!uploadId) lines.push(``, `⚠️ 画像のアップロードに失敗したためテキストのみ登録`);
+  await sendMessage(env, lines.join("\n"));
 }
 
 async function handleUrl(env: Env, url: string): Promise<void> {

--- a/cf-worker/test/fixtures/telegram-updates.json
+++ b/cf-worker/test/fixtures/telegram-updates.json
@@ -54,5 +54,16 @@
       "chat": { "id": 999999999 },
       "text": "/tasks"
     }
+  },
+  "photoMessage": {
+    "update_id": 1008,
+    "message": {
+      "message_id": 8,
+      "chat": { "id": 123456789 },
+      "photo": [
+        { "file_id": "photo-small", "file_size": 1024 },
+        { "file_id": "photo-large", "file_size": 102400 }
+      ]
+    }
   }
 }

--- a/cf-worker/test/integration/telegram-webhook.test.ts
+++ b/cf-worker/test/integration/telegram-webhook.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../src/clients/notion.js", () => ({
   completeTask: vi.fn().mockResolvedValue(undefined),
   cancelTask: vi.fn().mockResolvedValue(undefined),
   updateTaskDue: vi.fn().mockResolvedValue(undefined),
+  uploadImageToNotion: vi.fn().mockResolvedValue("upload-id-001"),
 }));
 
 vi.mock("../../src/clients/telegram.js", () => ({
@@ -21,7 +22,7 @@ vi.mock("../../src/clients/anthropic.js", () => ({
   analyzeEmail: vi.fn(),
   extractTasksFromText: vi.fn().mockResolvedValue([]),
   extractTasksFromUrlContent: vi.fn().mockResolvedValue([]),
-  extractTasksFromImage: vi.fn().mockResolvedValue([]),
+  analyzeImage: vi.fn().mockResolvedValue({ summary: "", tasks: [] }),
   summarizeDay: vi.fn().mockResolvedValue("ブリーフィング"),
 }));
 

--- a/cf-worker/test/unit/handlers/telegram.test.ts
+++ b/cf-worker/test/unit/handlers/telegram.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../../src/clients/notion.js", () => ({
   completeTask: vi.fn().mockResolvedValue(undefined),
   cancelTask: vi.fn().mockResolvedValue(undefined),
   updateTaskDue: vi.fn().mockResolvedValue(undefined),
+  uploadImageToNotion: vi.fn().mockResolvedValue("upload-id-001"),
 }));
 
 vi.mock("../../../src/clients/telegram.js", () => ({
@@ -33,7 +34,7 @@ vi.mock("../../../src/handlers/briefing.js", () => ({
 vi.mock("../../../src/clients/anthropic.js", () => ({
   extractTasksFromText: vi.fn().mockResolvedValue([{ title: "テストタスク", due: null, priority: "medium" }]),
   extractTasksFromUrlContent: vi.fn().mockResolvedValue([]),
-  extractTasksFromImage: vi.fn().mockResolvedValue([]),
+  analyzeImage: vi.fn().mockResolvedValue({ summary: "", tasks: [] }),
   summarizeDay: vi.fn().mockResolvedValue("今日のブリーフィング"),
 }));
 
@@ -90,6 +91,50 @@ describe("handleTelegramWebhook", () => {
 
     await handleTelegramWebhook(env, telegramFixtures.tasksCommand);
     expect(getOpenTasks).toHaveBeenCalledWith(env);
+  });
+
+  it("photo message: consolidates all extracted tasks into ONE Notion task with image attached", async () => {
+    const env = createMockEnv();
+    const { addTask, uploadImageToNotion } = await import("../../../src/clients/notion.js");
+    const { analyzeImage } = await import("../../../src/clients/anthropic.js");
+    const { getFileUrl } = await import("../../../src/clients/telegram.js");
+
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue("https://api.telegram.org/file/bot/photo.jpg");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new ArrayBuffer(1024), { status: 200 })));
+    (analyzeImage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "週末の買い物リスト",
+      tasks: [
+        { title: "牛乳を買う", priority: "medium", due: null },
+        { title: "卵を買う", priority: "high", due: "2026-05-01" },
+        { title: "パンを買う", priority: "low", due: null },
+      ],
+    });
+
+    await handleTelegramWebhook(env, telegramFixtures.photoMessage);
+
+    expect(uploadImageToNotion).toHaveBeenCalledTimes(1);
+    expect(addTask).toHaveBeenCalledTimes(1);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ title: "週末の買い物リスト", priority: "high", due: "2026-05-01", source: "Telegram" }),
+      ["牛乳を買う", "卵を買う", "パンを買う"],
+      undefined,
+      "upload-id-001",
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("photo message: largest photo is selected", async () => {
+    const env = createMockEnv();
+    const { getFileUrl } = await import("../../../src/clients/telegram.js");
+
+    (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue("https://api.telegram.org/file/bot/photo.jpg");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new ArrayBuffer(1024), { status: 200 })));
+
+    await handleTelegramWebhook(env, telegramFixtures.photoMessage);
+
+    expect(getFileUrl).toHaveBeenCalledWith(env, "photo-large");
+    vi.unstubAllGlobals();
   });
 
   it("/done command without prior /tasks sends guidance message", async () => {


### PR DESCRIPTION
## Summary

Telegram 画像送信時の挙動を改善。**PR #22 を置き換える実装**（master からの離れが大きいので別ブランチで起こし直し）。

### 解決する問題

1. **画像が添付されない** — そもそも未デプロイ（PR #22 未マージ）
2. **タスクが細切れ** — 画像 1 枚から複数 Notion ページが作られて見通しが悪い

### 変更内容

- `analyzeImage` 新設（`{summary, tasks}` を返す）
  - プロンプトで「関連アクションは細切れにせず少ない数にまとめる」よう誘導
- `handlePhoto` は常に **1 タスク** として登録：
  - `title`  : `summary`（不足時は最初の task title → `"📷 画像メモ"` にフォールバック）
  - `due`    : 各タスクの最早 due
  - `priority`: 各タスクの最高優先度
  - 各タスク `title` は to_do チェックリスト化
- `uploadImageToNotion`（Notion File Upload API）でアップロード
- `addTask` に `imageUploadId` 引数を追加し、image ブロックをページ本文に追加
- アップロード失敗時はタスクは作るが Telegram 通知に明示

### Notion DB プロパティ要件

変更なし（既存スキーマで動く）。

## Test plan

- [x] `npm test` 全 101 件パス（新規 photo テスト 2 件含む）
- [ ] マージ後、Telegram に画像送信 → Notion で 1 タスク + チェックリスト + 画像本文を確認

### Closes
- closes #22 (置き換え)