### PR TITLE
feat: メール由来タスクの Telegram 通知を Web アプリリンクに統一

### DIFF
--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -3,6 +3,7 @@ import { listAllMessages, getMessage, parseMessage, isCalendarInvite, archiveMes
 import { analyzeEmail } from "../clients/anthropic.js";
 import { addTask, updateTaskFromReply, getTaskStatus } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
+import { taskLink } from "./telegram.js";
 import {
   getThreadMapEntry,
   setThreadMapEntry,
@@ -75,7 +76,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
           await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null, body);
           if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
           taskLines.push(
-            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  ${taskLink(existingPageId)}`,
           );
         } else {
           const pageId = await addTask(
@@ -89,8 +90,9 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
             await setSenderForTask(env, pageId, senderEmail);
             if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
           }
+          const link = pageId ? taskLink(pageId) : `[📧 Gmail で開く](${gmailUrl})`;
           taskLines.push(
-            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  [📧 Gmail で開く](${gmailUrl})`,
+            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  ${link}`,
           );
         }
       } else {

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -13,7 +13,7 @@ const OPERATING_START_HOUR = 8;
 const OPERATING_END_HOUR = 21;
 const TODO_APP_BASE_URL = "https://todo.eh6gac4.work";
 
-function taskLink(pageId: string): string {
+export function taskLink(pageId: string): string {
   return `[🔗 アプリで開く](${TODO_APP_BASE_URL}/?task=${pageId})`;
 }
 


### PR DESCRIPTION
## Summary
- `checkGmail` がタスク登録時に Telegram へ送る通知のリンクを `https://todo.eh6gac4.work/?task=<pageId>` に変更（既存タスク更新パスも含む）
- Telegram・写真・URL 経由のタスク登録と挙動を揃え、登録直後にタスク詳細をワンタップで開けるようにした
- Notion ページの URL プロパティ（sourceUrl）は引き続き Gmail URL を保持。メール本文への遡及参照は失わない
- `pageId` 取得失敗時は従来の Gmail リンクにフォールバック

## Test plan
- [x] `npm test -- test/unit/handlers/gmail.test.ts`（11 件 pass）
- [ ] デプロイ後、メール経由でタスク登録 → Telegram 通知のリンク先が `todo.eh6gac4.work/?task=...` になることを確認
- [ ] 同一スレッドへの返信で既存タスクが更新される場合も Web アプリリンクになることを確認
- [ ] Notion 側のタスクページの URL プロパティが Gmail URL のまま保存されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)