### PR TITLE
feat: /admin/run でジョブを名前指定で手動再実行

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ npm run secrets:push
 | `GOOGLE_CLIENT_ID` | Google Cloud Console → 認証情報 |
 | `GOOGLE_CLIENT_SECRET` | 同上 |
 | `GOOGLE_REFRESH_TOKEN` | `data/token.json` の `refresh_token` |
+| `ADMIN_TOKEN` | `openssl rand -hex 32` で生成（`/admin/run` の Bearer 認証用、任意） |
 
 ### 5. デプロイ & Webhook 登録
 
@@ -260,3 +261,20 @@ curl "http://localhost:8787/__scheduled?cron=0+4+*+*+*"
 ```
 
 `cron` クエリは `wrangler.toml` の cron 文字列をスペース区切り → `+` 置換した値を使う。
+
+### 本番ジョブの手動再実行 (`/admin/run`)
+
+朝のジョブが失敗した場合などに、本番 Worker のジョブをジョブ名で再実行できる。`ADMIN_TOKEN`（`wrangler secret put ADMIN_TOKEN` で登録）を Bearer 認証に使う。
+
+```bash
+TOKEN=$(cat /path/to/admin_token)
+URL="https://ambient-agent.toshiki-cho-dev.workers.dev/admin/run"
+
+# morning_prep を再実行
+curl -X POST -H "Authorization: Bearer $TOKEN" "$URL?job=morningPrep"
+
+# morning_briefing を再実行
+curl -X POST -H "Authorization: Bearer $TOKEN" "$URL?job=morningBriefing"
+```
+
+利用可能な `job` 名: `hourlyGmail` / `morningPrep` / `morningBriefing` / `taskReminder` / `staleTasksNotice`。`ADMIN_TOKEN` 未設定なら 503、トークン不一致なら 401、未知のジョブ名なら 400 を返す。

--- a/cf-worker/.dev.vars.example
+++ b/cf-worker/.dev.vars.example
@@ -26,3 +26,9 @@ ANTHROPIC_API_KEY=sk-ant-
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REFRESH_TOKEN=
+
+# ------------------------------------------------------------
+# /admin/run 用トークン（手動でジョブ再実行する際の Bearer 認証）
+# `openssl rand -hex 32` で生成した値を入れる。本番は wrangler secret put ADMIN_TOKEN
+# ------------------------------------------------------------
+ADMIN_TOKEN=

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -24,12 +24,20 @@ async function morningBriefing(env: Env): Promise<void> {
   await sendEmailDigest(env);
 }
 
-const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
-  "30 22-23,0-12 * * *": hourlyGmail,  // 毎時30分 (JST 07:30-21:30): silent gmail batch
-  "50 22 * * *": morningPrep,          // 07:50 JST: learn→calendar→escalation
-  "0 23 * * *": morningBriefing,       // 08:00 JST: briefing→cost→due_soon→email_digest
-  "0 4 * * *": sendTaskReminder,       // 13:00 JST
-  "0 0 * * 1": sendStaleTasksNotice,   // 月 09:00 JST
+const JOBS: Record<string, (env: Env) => Promise<void>> = {
+  hourlyGmail,
+  morningPrep,
+  morningBriefing,
+  taskReminder: sendTaskReminder,
+  staleTasksNotice: sendStaleTasksNotice,
+};
+
+const CRON_JOBS: Record<string, keyof typeof JOBS> = {
+  "30 22-23,0-12 * * *": "hourlyGmail",  // 毎時30分 (JST 07:30-21:30): silent gmail batch
+  "50 22 * * *": "morningPrep",          // 07:50 JST: learn→calendar→escalation
+  "0 23 * * *": "morningBriefing",       // 08:00 JST: briefing→cost→due_soon→email_digest
+  "0 4 * * *": "taskReminder",           // 13:00 JST
+  "0 0 * * 1": "staleTasksNotice",       // 月 09:00 JST
 };
 
 export default {
@@ -46,21 +54,41 @@ export default {
       return new Response("OK");
     }
 
+    if (url.pathname === "/admin/run" && req.method === "POST") {
+      const expected = env.ADMIN_TOKEN;
+      if (!expected) return new Response("ADMIN_TOKEN not configured", { status: 503 });
+      const auth = req.headers.get("authorization") ?? "";
+      const provided = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+      if (provided !== expected) return new Response("unauthorized", { status: 401 });
+
+      const jobName = url.searchParams.get("job") ?? "";
+      const job = JOBS[jobName];
+      if (!job) {
+        return new Response(`unknown job: ${jobName}. valid: ${Object.keys(JOBS).join(", ")}`, { status: 400 });
+      }
+      try {
+        await job(env);
+        return new Response(`ok: ${jobName}\n`);
+      } catch (err) {
+        console.error(`admin/run ${jobName} failed:`, err);
+        return new Response(`error: ${err}\n`, { status: 500 });
+      }
+    }
+
     return new Response("ambient-agent", { status: 200 });
   },
 
   async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
-    const job = CRON_JOBS[event.cron];
-    if (!job) {
+    const jobName = CRON_JOBS[event.cron];
+    if (!jobName) {
       console.warn("Unknown cron:", event.cron);
       return;
     }
 
     try {
-      await job(env);
+      await JOBS[jobName](env);
     } catch (err) {
-      const jobName = Object.entries(CRON_JOBS).find(([, fn]) => fn === job)?.[0] ?? event.cron;
-      const msg = `⚠️ *Ambient Agent エラー*\nJob: \`${jobName}\`\n\`\`\`\n${err}\n\`\`\``;
+      const msg = `⚠️ *Ambient Agent エラー*\nJob: \`${jobName}\` (\`${event.cron}\`)\n\`\`\`\n${err}\n\`\`\``;
       console.error(msg, err);
       try {
         await sendMessage(env, msg);

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -16,6 +16,7 @@ export interface Env {
   COST_REPORT_HOUR?: string;
   GMAIL_TASK_LABEL?: string;
   GMAIL_ACCOUNT_INDEX?: string;
+  ADMIN_TOKEN?: string;
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary
- 朝のジョブ (\`morningPrep\` / \`morningBriefing\`) が失敗した際に、Dashboard を経由せず curl で再実行できる Bearer 認証付き管理エンドポイント \`/admin/run?job=<name>\` を追加
- \`CRON_JOBS\` を「cron 式 → ジョブ名」のマップに整理し、\`JOBS\` マップを単一の真実の源として scheduled / fetch の両方から参照
- README に手順、\`.dev.vars.example\` に \`ADMIN_TOKEN\` を追記

## Test plan
- [x] vitest 全 101 件パス
- [x] \`wrangler dev\` で localhost:8787 に対し 503 / 401 / 400 / 200 のレスポンス確認
- [x] 本番デプロイ後、\`morningPrep\` と \`morningBriefing\` を curl 並列実行 → 200 OK、Telegram に通知到着
- [ ] マージ後 master でも \`/admin/run\` が同じ挙動になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)