### PR TITLE
fix: Gmail本文を常にUTF-8でデコード（ISO-2022-JP 宣言メールの文字化け修正）

### DIFF
--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -31,22 +31,14 @@ function isCalendarInvite(payload: GmailPayload): boolean {
   return (payload.parts ?? []).some(isCalendarInvite);
 }
 
-function extractCharset(payload: GmailPayload): string {
-  const ct = (payload.headers ?? []).find((h) => h.name.toLowerCase() === "content-type")?.value ?? "";
-  const m = ct.match(/charset\s*=\s*"?([^";]+)"?/i);
-  return m ? m[1].trim().toLowerCase() : "utf-8";
-}
+// Gmail API は body.data を元メールの charset に関係なく UTF-8 へ正規化して返すため、
+// Content-Type ヘッダの charset= は無視して常に UTF-8 でデコードする。
+const UTF8_DECODER = new TextDecoder("utf-8");
 
-function decodeBase64Url(data: string, charset: string): string {
+function decodeBase64Url(data: string): string {
   const binary = atob(data.replace(/-/g, "+").replace(/_/g, "/"));
   const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  let decoder: TextDecoder;
-  try {
-    decoder = new TextDecoder(charset);
-  } catch {
-    decoder = new TextDecoder("utf-8");
-  }
-  return decoder.decode(bytes);
+  return UTF8_DECODER.decode(bytes);
 }
 
 function extractBody(payload: GmailPayload): string {
@@ -54,7 +46,7 @@ function extractBody(payload: GmailPayload): string {
     const data = payload.body?.data ?? "";
     if (!data) return "";
     try {
-      return decodeBase64Url(data, extractCharset(payload));
+      return decodeBase64Url(data);
     } catch {
       return "";
     }

--- a/cf-worker/test/unit/clients/gmail-api.test.ts
+++ b/cf-worker/test/unit/clients/gmail-api.test.ts
@@ -77,8 +77,11 @@ describe("parseMessage body decoding", () => {
     expect(parseMessage(msg as never).body).toBe(body);
   });
 
-  it("falls back to UTF-8 for unsupported charset label", () => {
-    const body = "サポート外 charset でもUTF-8として読む";
+  it("decodes as UTF-8 even when Content-Type declares charset=ISO-2022-JP (Gmail normalizes body to UTF-8)", () => {
+    // Gmail API は元メールの charset に関係なく body.data を UTF-8 バイト列で返すが、
+    // Content-Type ヘッダは元メールの宣言値（例: ISO-2022-JP）が残る。
+    // charset を信用して ISO-2022-JP デコーダに通すと UTF-8 バイト列が壊れるため、常に UTF-8 で読む。
+    const body = "利用者ID　0017902933　様\r\nまもなく下記の資料の返却期限日となりますので、お知らせいたします。";
     const msg = {
       id: "m4",
       threadId: "t4",
@@ -87,7 +90,7 @@ describe("parseMessage body decoding", () => {
         headers: [
           { name: "Subject", value: "x" },
           { name: "From", value: "x@example.com" },
-          { name: "Content-Type", value: "text/plain; charset=x-unknown-codec" },
+          { name: "Content-Type", value: "text/plain; charset=ISO-2022-JP" },
         ],
         body: { data: utf8B64Url(body) },
       },


### PR DESCRIPTION
## Summary
- Gmail API は body.data を **元メールの charset に関係なく UTF-8 バイト列で返す**が、Content-Type ヘッダの `charset=` は元メールの宣言値（例: `ISO-2022-JP`）のまま残る。従来コードは `charset=` を信用して `TextDecoder(charset)` に通していたため、JavaMail/Tomcat 系（例: 世田谷区立図書館の返却期限通知）から `ISO-2022-JP` 宣言で来るメールの本文が U+FFFD だらけになっていた。
- `extractCharset` を削除し、`body.data` を常に UTF-8 でデコードするよう修正。
- 回帰テストを 1 件差し替え（`charset=ISO-2022-JP` ヘッダ + UTF-8 バイト列で正常に読めること）。

## 検証
- 実際の Gmail API レスポンスを直接叩いて確認: 図書館メール（`Content-Type: text/plain; charset=ISO-2022-JP` 宣言）の `body.data` 先頭が `e5 88 a9 e7 94 a8`（UTF-8 で「利用」）になっており、ISO-2022-JP のエスケープシーケンス（`1b 24 42`）は含まれない。
- Python 版 `agent/gmail_handler.py:410` も以前から `decode("utf-8", errors="replace")` 固定でこの問題は出ていなかった。

## Test plan
- [x] `npx vitest run` → 14 files / 101 tests pass
- [ ] マージ後、本番で次の Gmail バッチ実行（`/30 22-23,0-12 * * *`）の本文が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)