### PR TITLE
feat: タスク登録時に Notion ページの絵文字アイコンを設定

### DIFF
--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -17,6 +17,7 @@ const EXTRACT_TASKS_PROMPT = `あなたはメールからタスクを抽出す�
     "title": "タスクのタイトル（簡潔に）",
     "due": "YYYY-MM-DD または YYYY-MM-DDTHH:MM または null（時刻が明示されていれば時刻付きで返す）",
     "priority": "high | medium | low",
+    "icon": "タスク内容を端的に表す絵文字を1文字（例: 📩 返信 / 📅 予定 / 💰 支払い / 📝 提出 / 🔍 確認 / 🛒 買い物）",
     "source": "Gmail"
   }
 ]
@@ -26,6 +27,7 @@ const EXTRACT_TASKS_PROMPT = `あなたはメールからタスクを抽出す�
 - 返信・確認・提出・対応などのアクション動詞を含む文をタスクとして抽出する
 - 期日が明示されていればそれを due に設定する（不明な場合は null）
 - 緊急・至急・本日中 → high、それ以外は medium を基本とする
+- icon: タスクの性質（返信・予定・支払い・確認・買い物 等）を最もよく表す絵文字を Unicode 1 文字だけ返す。迷ったら 📋
 - 広告・通知・ニュースレターからはタスクを抽出しない`;
 
 const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタントです。
@@ -42,6 +44,7 @@ const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタ�
       "title": "タスクのタイトル（簡潔に）",
       "due": "YYYY-MM-DD または YYYY-MM-DDTHH:MM または null",
       "priority": "high | medium | low",
+      "icon": "タスク内容を端的に表す絵文字を1文字（例: 📩 返信 / 📅 予定 / 💰 支払い / 📝 提出 / 🔍 確認 / 🛒 買い物）",
       "source": "Gmail"
     }
   ]
@@ -53,6 +56,7 @@ const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタ�
 - tasks: 返信・確認・提出・対応などのアクション動詞を含む文をタスクとして抽出する
 - 期日が明示されていればそれを due に設定する（不明な場合は null）
 - 緊急・至急・本日中 → high、それ以外は medium を基本とする
+- icon: タスクの性質（返信・予定・支払い・確認・買い物 等）を最もよく表す絵文字を Unicode 1 文字だけ返す。迷ったら 📋
 - 広告・通知・ニュースレターからはタスクを抽出せず tasks は []`;
 
 interface AnthropicResponse {
@@ -156,6 +160,7 @@ const ANALYZE_IMAGE_PROMPT = `あなたは画像からタスクを分析する�
       "title": "具体的にやること（簡潔に）",
       "due": "YYYY-MM-DD または null",
       "priority": "high | medium | low",
+      "icon": "タスク内容を端的に表す絵文字を1文字（例: 🧾 レシート / 📝 メモ / 🛒 買い物 / 💰 支払い / 📅 予定 / 🔍 確認）",
       "source": "Telegram"
     }
   ]
@@ -166,7 +171,8 @@ const ANALYZE_IMAGE_PROMPT = `あなたは画像からタスクを分析する�
 - summary: 「何の画像か / なぜ撮ったと考えられるか」を1文に。タスク登録時のタイトルになるので具体的に
 - tasks: 関連する一連のアクションは細切れにせず、できるだけ少ない数にまとめる
 - 期日が画像内に明示されていれば due に設定する（不明なら null）
-- 緊急・至急 → high、通常 → medium`;
+- 緊急・至急 → high、通常 → medium
+- icon: タスクの性質（レシート整理・メモ転記・買い物・支払い・予定登録 等）を最もよく表す絵文字を Unicode 1 文字だけ返す。迷ったら 📋`;
 
 export async function analyzeImage(env: Env, imageData: ArrayBuffer, mediaType: string): Promise<EmailAnalysis> {
   const userContent = [

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -196,6 +196,10 @@ export async function addTask(
     properties,
   };
 
+  if (task.icon) {
+    body.icon = { type: "emoji", emoji: task.icon };
+  }
+
   const checklistBlocks = (checklist ?? []).map((item) => ({
     object: "block",
     type: "to_do",

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -12,6 +12,23 @@ const STATUS_CANCELLED = "中止";
 const EMAIL_BODY_MAX_CHARS = 10000;
 const NOTION_RICH_TEXT_MAX = 2000;
 
+// LLM が "返信" や "📩 返信" のような非絵文字/混在文字列を返すと
+// Notion の icon.emoji が 400 で拒否され、タスク登録ごと失敗する。
+// 絵文字（ZWJ シーケンス・肌色修飾・国旗・キーキャップ含む）のみ通し、
+// それ以外は undefined を返して icon を付けずに登録を継続させる。
+const EMOJI_ALLOWED_RE =
+  /^(?:\p{Extended_Pictographic}|\p{Emoji_Modifier}|\p{Regional_Indicator}|[\u200D\uFE0F\u20E3#*0-9])+$/u;
+const EMOJI_REQUIRED_RE = /[\p{Extended_Pictographic}\p{Regional_Indicator}\u20E3]/u;
+
+export function sanitizeEmoji(icon?: string): string | undefined {
+  if (!icon) return undefined;
+  const trimmed = icon.trim();
+  if (!trimmed || trimmed.length > 16) return undefined;
+  if (!EMOJI_ALLOWED_RE.test(trimmed)) return undefined;
+  if (!EMOJI_REQUIRED_RE.test(trimmed)) return undefined;
+  return trimmed;
+}
+
 function buildEmailBodyBlocks(bodyText: string, headingLabel: string): Array<Record<string, unknown>> {
   const trimmed = bodyText.trim();
   if (!trimmed) return [];
@@ -196,8 +213,9 @@ export async function addTask(
     properties,
   };
 
-  if (task.icon) {
-    body.icon = { type: "emoji", emoji: task.icon };
+  const emoji = sanitizeEmoji(task.icon);
+  if (emoji) {
+    body.icon = { type: "emoji", emoji };
   }
 
   const checklistBlocks = (checklist ?? []).map((item) => ({

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -81,7 +81,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
         } else {
           const pageId = await addTask(
             env,
-            { title: subject, due: dues[0] ?? null, priority: best.priority, source: "Gmail", sourceUrl: gmailUrl },
+            { title: subject, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Gmail", sourceUrl: gmailUrl },
             checklist,
             body,
           );

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -79,7 +79,7 @@ async function handleCommand(env: Env, text: string): Promise<void> {
         await sendMessage(env, "使い方: `/add 〇〇を確認する`");
         return;
       }
-      const id = await addTask(env, { title: arg, source: "Telegram", priority: "medium" });
+      const id = await addTask(env, { title: arg, source: "Telegram", priority: "medium", icon: "📌" });
       const link = id ? `\n\n${taskLink(id)}` : "";
       await sendMessage(env, `✅ タスクを追加しました\n\n*${arg}*${link}`);
       return;
@@ -227,12 +227,12 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
   const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
   const best = tasks.length
     ? tasks.reduce((a, b) => ((priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b))
-    : { priority: "medium" as const };
+    : { priority: "medium" as const, icon: "🖼" as string | undefined };
   const title = (summary || tasks[0]?.title || "📷 画像メモ").slice(0, 200);
 
   const id = await addTask(
     env,
-    { title, due: dues[0] ?? null, priority: best.priority, source: "Telegram" },
+    { title, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Telegram" },
     checklist,
     undefined,
     uploadId ?? undefined,
@@ -261,7 +261,9 @@ async function handleUrl(env: Env, url: string): Promise<void> {
   }
 
   const tasks = await extractTasksFromUrlContent(env, url, content);
-  const finalTasks = tasks.length ? tasks : [{ title: `${pageTitle}を確認する`, due: null, priority: "medium" as const }];
+  const finalTasks = tasks.length
+    ? tasks
+    : [{ title: `${pageTitle}を確認する`, due: null, priority: "medium" as const, icon: "🔍" }];
 
   const created: Array<{ title: string; id: string | null }> = [];
   for (const task of finalTasks) {

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -1,4 +1,4 @@
-import type { Env } from "../types.js";
+import type { Env, ExtractedTask } from "../types.js";
 import { sendMessage, getFileUrl } from "../clients/telegram.js";
 import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, uploadImageToNotion } from "../clients/notion.js";
 import { extractTasksFromText, extractTasksFromUrlContent, analyzeImage } from "../clients/anthropic.js";
@@ -12,6 +12,9 @@ const URL_PATTERN = /https?:\/\/\S+/;
 const OPERATING_START_HOUR = 8;
 const OPERATING_END_HOUR = 21;
 const TODO_APP_BASE_URL = "https://todo.eh6gac4.work";
+
+// LLM がタスクを抽出できなかった経路のフォールバック絵文字。
+const FALLBACK_ICON = { add: "📌", photo: "🖼", url: "🔍" } as const;
 
 export function taskLink(pageId: string): string {
   return `[🔗 アプリで開く](${TODO_APP_BASE_URL}/?task=${pageId})`;
@@ -79,7 +82,7 @@ async function handleCommand(env: Env, text: string): Promise<void> {
         await sendMessage(env, "使い方: `/add 〇〇を確認する`");
         return;
       }
-      const id = await addTask(env, { title: arg, source: "Telegram", priority: "medium", icon: "📌" });
+      const id = await addTask(env, { title: arg, source: "Telegram", priority: "medium", icon: FALLBACK_ICON.add });
       const link = id ? `\n\n${taskLink(id)}` : "";
       await sendMessage(env, `✅ タスクを追加しました\n\n*${arg}*${link}`);
       return;
@@ -225,9 +228,9 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
   const checklist = tasks.map((t) => t.title);
   const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
   const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
-  const best = tasks.length
+  const best: Pick<ExtractedTask, "priority" | "icon"> = tasks.length
     ? tasks.reduce((a, b) => ((priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b))
-    : { priority: "medium" as const, icon: "🖼" as string | undefined };
+    : { priority: "medium", icon: FALLBACK_ICON.photo };
   const title = (summary || tasks[0]?.title || "📷 画像メモ").slice(0, 200);
 
   const id = await addTask(
@@ -263,7 +266,7 @@ async function handleUrl(env: Env, url: string): Promise<void> {
   const tasks = await extractTasksFromUrlContent(env, url, content);
   const finalTasks = tasks.length
     ? tasks
-    : [{ title: `${pageTitle}を確認する`, due: null, priority: "medium" as const, icon: "🔍" }];
+    : [{ title: `${pageTitle}を確認する`, due: null, priority: "medium" as const, icon: FALLBACK_ICON.url }];
 
   const created: Array<{ title: string; id: string | null }> = [];
   for (const task of finalTasks) {

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -34,12 +34,14 @@ export interface TaskInput {
   priority?: "high" | "medium" | "low";
   source?: string;
   sourceUrl?: string;
+  icon?: string;
 }
 
 export interface ExtractedTask {
   title: string;
   due: string | null;
   priority: "high" | "medium" | "low";
+  icon?: string;
 }
 
 export interface EmailAnalysis {

--- a/cf-worker/test/fixtures/claude-responses.json
+++ b/cf-worker/test/fixtures/claude-responses.json
@@ -3,7 +3,7 @@
     "content": [
       {
         "type": "text",
-        "text": "[{\"title\": \"プロジェクト資料を確認する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"source\": \"Gmail\"}]"
+        "text": "[{\"title\": \"プロジェクト資料を確認する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"icon\": \"🔍\", \"source\": \"Gmail\"}]"
       }
     ],
     "usage": { "input_tokens": 150, "output_tokens": 50 }
@@ -12,7 +12,7 @@
     "content": [
       {
         "type": "text",
-        "text": "{\"summary\": \"田中さんからプロジェクトの進捗確認依頼。期限は4月30日。\", \"tasks\": [{\"title\": \"プロジェクト進捗を報告する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"source\": \"Gmail\"}]}"
+        "text": "{\"summary\": \"田中さんからプロジェクトの進捗確認依頼。期限は4月30日。\", \"tasks\": [{\"title\": \"プロジェクト進捗を報告する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"icon\": \"📩\", \"source\": \"Gmail\"}]}"
       }
     ],
     "usage": { "input_tokens": 200, "output_tokens": 80 }

--- a/cf-worker/test/unit/clients/anthropic.test.ts
+++ b/cf-worker/test/unit/clients/anthropic.test.ts
@@ -19,6 +19,7 @@ describe("analyzeEmail", () => {
     expect(result.tasks).toHaveLength(1);
     expect(result.tasks[0].title).toBe("プロジェクト進捗を報告する");
     expect(result.tasks[0].priority).toBe("high");
+    expect(result.tasks[0].icon).toBe("📩");
   });
 
   it("returns empty tasks array for newsletters", async () => {
@@ -57,6 +58,7 @@ describe("extractTasksFromText", () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0].title).toBe("プロジェクト資料を確認する");
     expect(tasks[0].due).toBe("2026-04-30");
+    expect(tasks[0].icon).toBe("🔍");
   });
 
   it("returns empty array when no JSON list in response", async () => {

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks } from "../../../src/clients/notion.js";
+import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, sanitizeEmoji } from "../../../src/clients/notion.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import notionFixtures from "../../fixtures/notion-tasks.json" assert { type: "json" };
 
@@ -109,6 +109,20 @@ describe("addTask", () => {
     await addTask(env, { title: "アイコンなし" });
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.icon).toBeUndefined();
+  });
+
+  it("drops invalid icon and still creates the task (no 400 from Notion)", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // LLM が絵文字でなく説明文を返したケース
+    const id = await addTask(env, { title: "不正アイコン", icon: "📩 返信" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.icon).toBeUndefined();
+    expect(body.properties).toBeDefined();
+    expect(id).toBe(notionFixtures.createResponse.id);
   });
 
   it("does not append body blocks when bodyText is empty", async () => {
@@ -233,5 +247,34 @@ describe("escalatePriorityTasks", () => {
     const escalated = await escalatePriorityTasks(env);
     expect(escalated).toHaveLength(1);
     expect(escalated[0].title).toBe("緊急タスク");
+  });
+});
+
+describe("sanitizeEmoji", () => {
+  it("keeps a plain single emoji", () => {
+    expect(sanitizeEmoji("📩")).toBe("📩");
+  });
+
+  it("keeps emoji with variation selector / ZWJ sequence / skin tone / flag / keycap", () => {
+    expect(sanitizeEmoji("✋️")).toBe("✋️");
+    expect(sanitizeEmoji("🧑‍💻")).toBe("🧑‍💻");
+    expect(sanitizeEmoji("👍🏽")).toBe("👍🏽");
+    expect(sanitizeEmoji("🇯🇵")).toBe("🇯🇵");
+    expect(sanitizeEmoji("1️⃣")).toBe("1️⃣");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeEmoji("  📅 ")).toBe("📅");
+  });
+
+  it("drops non-emoji / mixed / empty input", () => {
+    expect(sanitizeEmoji(undefined)).toBeUndefined();
+    expect(sanitizeEmoji("")).toBeUndefined();
+    expect(sanitizeEmoji("   ")).toBeUndefined();
+    expect(sanitizeEmoji("返信")).toBeUndefined();
+    expect(sanitizeEmoji("task")).toBeUndefined();
+    expect(sanitizeEmoji("📩 返信")).toBeUndefined();
+    expect(sanitizeEmoji(":email:")).toBeUndefined();
+    expect(sanitizeEmoji("9".repeat(20))).toBeUndefined();
   });
 });

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -89,6 +89,28 @@ describe("addTask", () => {
     expect(lastChunk).toContain("…(以下省略)");
   });
 
+  it("sets page icon when icon is provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "絵文字アイコン付き", icon: "📩" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.icon).toEqual({ type: "emoji", emoji: "📩" });
+  });
+
+  it("omits icon field when not provided", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "アイコンなし" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.icon).toBeUndefined();
+  });
+
   it("does not append body blocks when bodyText is empty", async () => {
     const env = createMockEnv();
     const fetchMock = vi.fn()

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -78,6 +78,38 @@ describe("checkGmail", () => {
     );
   });
 
+  it("passes the LLM-extracted icon through to addTask", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry } = await import("../../../src/storage/d1.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-001", threadId: "thread-001" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "支払いのご案内",
+      body: "内容",
+      senderEmail: "billing@example.com",
+      threadId: "thread-001",
+      gmailUrl: "https://mail.google.com/mail/u/0/#search/rfc822msgid:",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "請求書の支払い依頼",
+      tasks: [{ title: "支払う", priority: "high", due: "2026-05-20", icon: "💰" }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-pay-001");
+
+    await checkGmail(env);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ source: "Gmail", icon: "💰" }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("updates existing task for reply email (same threadId)", async () => {
     const env = createMockEnv();
     const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");

--- a/cf-worker/test/unit/handlers/telegram.test.ts
+++ b/cf-worker/test/unit/handlers/telegram.test.ts
@@ -81,7 +81,7 @@ describe("handleTelegramWebhook", () => {
     await handleTelegramWebhook(env, telegramFixtures.addCommand);
     expect(addTask).toHaveBeenCalledWith(
       env,
-      expect.objectContaining({ title: "資料を確認する", source: "Telegram" }),
+      expect.objectContaining({ title: "資料を確認する", source: "Telegram", icon: "📌" }),
     );
     expect(sendMessage).toHaveBeenCalledWith(
       env,
@@ -99,7 +99,7 @@ describe("handleTelegramWebhook", () => {
   });
 
   it("photo message: consolidates all extracted tasks into ONE Notion task with image attached", async () => {
-    const env = createMockEnv();
+    const env = createMockEnv({ OPERATING_START_HOUR: "0", OPERATING_END_HOUR: "24" });
     const { addTask, uploadImageToNotion } = await import("../../../src/clients/notion.js");
     const { analyzeImage } = await import("../../../src/clients/anthropic.js");
     const { getFileUrl } = await import("../../../src/clients/telegram.js");
@@ -135,7 +135,7 @@ describe("handleTelegramWebhook", () => {
   });
 
   it("photo message: largest photo is selected", async () => {
-    const env = createMockEnv();
+    const env = createMockEnv({ OPERATING_START_HOUR: "0", OPERATING_END_HOUR: "24" });
     const { getFileUrl } = await import("../../../src/clients/telegram.js");
 
     (getFileUrl as ReturnType<typeof vi.fn>).mockResolvedValue("https://api.telegram.org/file/bot/photo.jpg");


### PR DESCRIPTION
## Summary
- AI（Claude）にタスク抽出と同時に絵文字アイコンを 1 文字選ばせ、Notion ページ作成時に `icon: { type: \"emoji\", emoji }` として付与する。
- 既存の `EXTRACT_TASKS_PROMPT` / `ANALYZE_EMAIL_PROMPT` / `ANALYZE_IMAGE_PROMPT` にフィールドを 1 行追加するだけで、Claude 呼び出しは増えない（1 タスクあたり追加 ~0.015 円）。
- AI を通さない経路は固定アイコンでフォールバック: `/add` は 📌、URL ハンドラの「ページタイトルを確認する」は 🔍、画像ハンドラのタスク 0 件時は 🖼。

## 主な変更
- `cf-worker/src/types.ts`: `TaskInput` / `ExtractedTask` に `icon?: string` を追加
- `cf-worker/src/clients/anthropic.ts`: 3 つの抽出プロンプトに `icon` フィールドを追加
- `cf-worker/src/clients/notion.ts`: `addTask()` で `body.icon` を組み立て
- `cf-worker/src/handlers/{gmail,telegram}.ts`: 呼び出し側で `icon` をパススルー
- テスト・フィクスチャ更新（103 件全て通過）
- photo テストが時刻ゲート（JST 8-21時）に依存していた既存問題をドライブバイで修正

## Test plan
- [x] `npm test` で 103 件全て通過
- [x] `npx tsc --noEmit` で src/ に型エラーなし
- [ ] dev 環境で `/add 牛乳を買う` を投げて Notion ページに 📌 が付くことを確認
- [ ] dev 環境で自由テキスト「明日までに見積もり返信」を送って AI 選定の絵文字が付くことを確認
- [ ] dev 環境で URL を 1 件送って AI 選定の絵文字 or 🔍 が付くことを確認
- [ ] テスト用 Gmail を 1 通受信してページに絵文字が付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)