### PR TITLE
fix: 日時指定タスクを作成時に Google カレンダーへ即時登録 (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 - 完了済みタスクのカレンダーイベントを削除、未着手タスクを Calendar に登録
 - 期限3日以内の medium タスクを high に昇格
 
+**カレンダー登録のタイミング:**
+- 期日付きタスクは作成時（Gmail / Telegram テキスト・画像・URL）に即座に Calendar へ登録（同日時刻指定タスクの取りこぼし防止）
+- morning_prep の同期は補完用。重複防止は D1 `calendar_sync` で行い、dedup キーは「期日時刻」単位（同一日付で時刻だけ変わっても反映）
+
 **morning_briefing の詳細:**
 - 直近 24 時間に hourly_gmail が処理したメールをまとめて1通の「📧 メール処理サマリ」として Telegram 送信
 

--- a/cf-worker/src/handlers/calendar.ts
+++ b/cf-worker/src/handlers/calendar.ts
@@ -1,4 +1,4 @@
-import type { Env } from "../types.js";
+import type { Env, Task } from "../types.js";
 import { getTodaysEvents, insertEvent, deleteEvent } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
 import { sendMessage } from "../clients/telegram.js";
@@ -9,8 +9,6 @@ export async function syncCalendar(env: Env): Promise<void> {
   const tasks = await getOpenTasks(env);
   const pendingIds = new Set(tasks.map((t) => t.pageId));
   const store = await getAllCalendarSync(env);
-
-  const today = new Date().toISOString().slice(0, 10);
 
   // Remove events for completed/deleted tasks
   for (const [pageId, { eventId }] of store) {
@@ -23,29 +21,60 @@ export async function syncCalendar(env: Env): Promise<void> {
     await deleteCalendarSync(env, pageId);
   }
 
-  // Sync pending tasks
+  // Sync pending tasks (same code path as the immediate-creation flow)
   for (const task of tasks) {
-    if (!task.due) continue;
-    const dueDate = task.due.slice(0, 10);
-    const isOverdue = dueDate < today;
-    const targetDate = isOverdue ? today : dueDate;
+    await syncTaskCalendarEvent(env, task);
+  }
+}
 
-    const record = store.get(task.pageId);
-    if (record?.calendarDate === targetDate) continue;
+/**
+ * 1 タスク分のカレンダーイベントを作成/更新する。
+ * 翌朝の syncCalendar cron とタスク作成時の即時同期で共通利用する。
+ * dedup キーは「カレンダー上の実日時 (eventDue)」単位。日付のみだと
+ * 同一日付で時刻だけ変わった際に古い時刻のまま取り残される不具合を防ぐ。
+ */
+export async function syncTaskCalendarEvent(
+  env: Env,
+  task: Pick<Task, "pageId" | "title" | "due">,
+): Promise<void> {
+  if (!task.due) return;
 
-    if (record?.eventId) {
-      try {
-        await deleteEvent(env, record.eventId);
-      } catch {
-        // ignore
-      }
+  const today = new Date().toISOString().slice(0, 10);
+  const dueDate = task.due.slice(0, 10);
+  const isOverdue = dueDate < today;
+  const targetDate = isOverdue ? today : dueDate;
+  const eventDue = isOverdue ? targetDate : task.due;
+
+  const record = await getCalendarSync(env, task.pageId);
+  if (record && record.calendarDate === eventDue) return;
+
+  if (record?.eventId) {
+    try {
+      await deleteEvent(env, record.eventId);
+    } catch {
+      // ignore
     }
+  }
 
-    const eventDue = isOverdue ? targetDate : task.due;
-    const eventId = await insertEvent(env, task.title, eventDue);
-    if (eventId) {
-      await setCalendarSync(env, task.pageId, eventId, targetDate);
-    }
+  const eventId = await insertEvent(env, task.title, eventDue);
+  if (eventId) {
+    await setCalendarSync(env, task.pageId, eventId, eventDue);
+  }
+}
+
+/**
+ * タスク作成直後にハンドラから呼ぶ即時同期。
+ * カレンダー/D1 の失敗がタスク作成・ユーザー応答を壊さないよう throw しない。
+ */
+export async function syncTaskCalendarEventSafe(
+  env: Env,
+  task: { pageId: string; title: string; due: string | null },
+): Promise<void> {
+  if (!task.due) return;
+  try {
+    await syncTaskCalendarEvent(env, task);
+  } catch (err) {
+    console.error("immediate calendar sync failed:", err);
   }
 }
 

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -4,6 +4,7 @@ import { analyzeEmail } from "../clients/anthropic.js";
 import { addTask, updateTaskFromReply, getTaskStatus } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { taskLink } from "./telegram.js";
+import { syncTaskCalendarEventSafe } from "./calendar.js";
 import {
   getThreadMapEntry,
   setThreadMapEntry,
@@ -89,6 +90,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
             if (threadId) await setThreadMapEntry(env, threadId, pageId);
             await setSenderForTask(env, pageId, senderEmail);
             if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+            await syncTaskCalendarEventSafe(env, { pageId, title: subject, due: dues[0] ?? null });
           }
           const link = pageId ? taskLink(pageId) : `[📧 Gmail で開く](${gmailUrl})`;
           taskLines.push(

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -4,7 +4,7 @@ import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, uploadI
 import { extractTasksFromText, extractTasksFromUrlContent, analyzeImage } from "../clients/anthropic.js";
 import { getSenderForTask } from "../storage/d1.js";
 import { getTaskCache, setTaskCache, getNoTaskSenders, addNoTaskSender, removeNoTaskSender } from "../storage/kv.js";
-import { deleteCalendarEventForTask } from "./calendar.js";
+import { deleteCalendarEventForTask, syncTaskCalendarEventSafe } from "./calendar.js";
 import { formatTaskList, sortTasks } from "./task-formatter.js";
 import { sendDailyBriefing } from "./briefing.js";
 
@@ -240,6 +240,7 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
     undefined,
     uploadId ?? undefined,
   );
+  if (id) await syncTaskCalendarEventSafe(env, { pageId: id, title, due: dues[0] ?? null });
 
   const lines = [`✅ タスクを登録しました`, ``, `*${title}*`];
   if (checklist.length) lines.push(...checklist.map((t) => `• ${t}`));
@@ -271,6 +272,7 @@ async function handleUrl(env: Env, url: string): Promise<void> {
   const created: Array<{ title: string; id: string | null }> = [];
   for (const task of finalTasks) {
     const id = await addTask(env, { ...task, source: "URL", sourceUrl: url });
+    if (id) await syncTaskCalendarEventSafe(env, { pageId: id, title: task.title, due: task.due ?? null });
     created.push({ title: task.title, id });
   }
   const body = created
@@ -323,6 +325,7 @@ export async function handleTelegramWebhook(env: Env, body: unknown): Promise<vo
     const created: Array<{ title: string; id: string | null }> = [];
     for (const task of tasks) {
       const id = await addTask(env, { ...task, source: "Telegram" });
+      if (id) await syncTaskCalendarEventSafe(env, { pageId: id, title: task.title, due: task.due ?? null });
       created.push({ title: task.title, id });
     }
     const body = created

--- a/cf-worker/test/unit/handlers/calendar.test.ts
+++ b/cf-worker/test/unit/handlers/calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendDueSoonNotice } from "../../../src/handlers/calendar.js";
+import { sendDueSoonNotice, syncTaskCalendarEvent, syncCalendar } from "../../../src/handlers/calendar.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import type { Task } from "../../../src/types.js";
 
@@ -64,5 +64,105 @@ describe("sendDueSoonNotice", () => {
 
     await sendDueSoonNotice(env);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncTaskCalendarEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a timed event and stores the full due as the dedup key (no prior record)", async () => {
+    const env = createMockEnv();
+    const { insertEvent, deleteEvent } = await import("../../../src/clients/gcal-api.js");
+    const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "歯医者", due: "2099-05-17T17:00:00" });
+
+    expect(deleteEvent).not.toHaveBeenCalled();
+    expect(insertEvent).toHaveBeenCalledWith(env, "歯医者", "2099-05-17T17:00:00");
+    expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "event-id", "2099-05-17T17:00:00");
+  });
+
+  it("skips entirely when the task has no due", async () => {
+    const env = createMockEnv();
+    const { insertEvent } = await import("../../../src/clients/gcal-api.js");
+    const { setCalendarSync } = await import("../../../src/storage/d1.js");
+
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "no due", due: null });
+
+    expect(insertEvent).not.toHaveBeenCalled();
+    expect(setCalendarSync).not.toHaveBeenCalled();
+  });
+
+  it("early-returns when the existing record matches the effective due", async () => {
+    const env = createMockEnv();
+    const { insertEvent, deleteEvent } = await import("../../../src/clients/gcal-api.js");
+    const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      eventId: "ev-old",
+      calendarDate: "2099-05-17T17:00:00",
+    });
+
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "歯医者", due: "2099-05-17T17:00:00" });
+
+    expect(deleteEvent).not.toHaveBeenCalled();
+    expect(insertEvent).not.toHaveBeenCalled();
+    expect(setCalendarSync).not.toHaveBeenCalled();
+  });
+
+  it("re-creates the event when only the time changes on the same date (dedup regression)", async () => {
+    const env = createMockEnv();
+    const { insertEvent, deleteEvent } = await import("../../../src/clients/gcal-api.js");
+    const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    // legacy row stored date-only
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      eventId: "ev-old",
+      calendarDate: "2099-05-17",
+    });
+
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "歯医者", due: "2099-05-17T17:00:00" });
+
+    expect(deleteEvent).toHaveBeenCalledWith(env, "ev-old");
+    expect(insertEvent).toHaveBeenCalledWith(env, "歯医者", "2099-05-17T17:00:00");
+    expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "event-id", "2099-05-17T17:00:00");
+  });
+
+  it("moves an overdue task to today (date-only)", async () => {
+    const env = createMockEnv();
+    const { insertEvent } = await import("../../../src/clients/gcal-api.js");
+    const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const today = new Date().toISOString().slice(0, 10);
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "期限切れ", due: "2000-01-01T09:00:00" });
+
+    expect(insertEvent).toHaveBeenCalledWith(env, "期限切れ", today);
+    expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "event-id", today);
+  });
+});
+
+describe("syncCalendar (delegates to syncTaskCalendarEvent)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates one event for a single due task with an empty sync store", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { insertEvent } = await import("../../../src/clients/gcal-api.js");
+    const { getAllCalendarSync, getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    (getAllCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue(new Map());
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "予定タスク", due: "2099-06-01T10:00:00", priority: "medium", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await syncCalendar(env);
+
+    expect(insertEvent).toHaveBeenCalledTimes(1);
+    expect(insertEvent).toHaveBeenCalledWith(env, "予定タスク", "2099-06-01T10:00:00");
+    expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "event-id", "2099-06-01T10:00:00");
   });
 });

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -28,6 +28,13 @@ vi.mock("../../../src/clients/telegram.js", () => ({
   escapeMd: (t: string) => t,
 }));
 
+vi.mock("../../../src/handlers/calendar.js", () => ({
+  syncTaskCalendarEventSafe: vi.fn().mockResolvedValue(undefined),
+  deleteCalendarEventForTask: vi.fn().mockResolvedValue(undefined),
+  getTodaysEvents: vi.fn().mockResolvedValue([]),
+  syncCalendar: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../../src/storage/d1.js", () => ({
   getThreadMapEntry: vi.fn(),
   setThreadMapEntry: vi.fn().mockResolvedValue(undefined),
@@ -75,6 +82,11 @@ describe("checkGmail", () => {
       expect.objectContaining({ title: "プロジェクトの進捗確認", source: "Gmail" }),
       ["進捗を報告する"],
       "内容",
+    );
+    const { syncTaskCalendarEventSafe } = await import("../../../src/handlers/calendar.js");
+    expect(syncTaskCalendarEventSafe).toHaveBeenCalledWith(
+      env,
+      { pageId: "page-new-001", title: "プロジェクトの進捗確認", due: "2026-04-30" },
     );
   });
 

--- a/cf-worker/test/unit/handlers/telegram.test.ts
+++ b/cf-worker/test/unit/handlers/telegram.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../../src/handlers/calendar.js", () => ({
   syncCalendar: vi.fn().mockResolvedValue(undefined),
   sendDueSoonNotice: vi.fn().mockResolvedValue(undefined),
   sendTaskReminder: vi.fn().mockResolvedValue(undefined),
+  syncTaskCalendarEventSafe: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../../src/handlers/briefing.js", () => ({
@@ -145,6 +146,25 @@ describe("handleTelegramWebhook", () => {
 
     expect(getFileUrl).toHaveBeenCalledWith(env, "photo-large");
     vi.unstubAllGlobals();
+  });
+
+  it("text message: immediately syncs a dated task to the calendar", async () => {
+    const env = createMockEnv({ OPERATING_START_HOUR: "0", OPERATING_END_HOUR: "24" });
+    const { extractTasksFromText } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { syncTaskCalendarEventSafe } = await import("../../../src/handlers/calendar.js");
+
+    (extractTasksFromText as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "歯医者に行く", due: "2099-05-17T17:00:00", priority: "high" },
+    ]);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-new");
+
+    await handleTelegramWebhook(env, telegramFixtures.textMessage);
+
+    expect(syncTaskCalendarEventSafe).toHaveBeenCalledWith(
+      env,
+      { pageId: "page-new", title: "歯医者に行く", due: "2099-05-17T17:00:00" },
+    );
   });
 
   it("/done command without prior /tasks sends guidance message", async () => {


### PR DESCRIPTION
## 背景 (Closes #34)

カレンダーイベントは従来 `syncCalendar()` の cron（07:50 JST `morning_prep`）でしか作成されず、日中に登録した期日付きタスク（特に「今日17時に会議」のような同日時刻指定）は翌朝の一括同期まで登録されず、同日タスクは実質取りこぼしていた。

## 変更

- **`calendar.ts`**: `syncCalendar` のタスク同期ループを `syncTaskCalendarEvent()` に抽出し、cron と即時同期で**完全同一ロジック**に。`syncTaskCalendarEventSafe()`（throw しない安全版）を追加
- **即時登録**: `gmail.ts`（新規作成ブランチ）、`telegram.ts`（画像/URL/テキスト経路）の `addTask` 成功直後に `syncTaskCalendarEventSafe` を呼び出し
- **dedup 修正**: 重複防止キーを日付単位 → 期日時刻 (`eventDue`) 単位に変更。同一日付で時刻だけ変わると cron がスキップしてカレンダー時刻が古いまま残る既存不具合も解消（スキーマ/migration 変更なし、`calendar_date` 列を不透明文字列として流用）
- **循環 import 回避**: `notion.ts` は無改修（`notion → calendar` 禁止辺）。ハンドラ側から呼ぶ
- エラー隔離: カレンダー/D1 失敗は `console.error` のみ、タスク作成・ユーザー応答を壊さない

### スコープ（確認済み）
- Gmail **新規作成のみ**。返信での期日変更（`updateTaskFromReply`）は従来どおり翌朝 cron 任せ
- Gmail 以外（Telegram テキスト/画像/URL）の日時指定タスクも即時登録対象
- `/add` は due 常に null のため対象外

## テスト

- `calendar.test.ts`: `syncTaskCalendarEvent` 6ケース（新規/ due 無し/ early-return/ **dedup 回帰**/ overdue/ `syncCalendar` 委譲）
- `gmail.test.ts`: `calendar.js` mock 追加 + 新規作成で即時同期呼び出しを検証
- `telegram.test.ts`: mock 拡張 + テキスト経路で日時タスクの即時同期を検証
- `npx vitest run`: 113 passed（既知の `task-formatter` timezone flaky 3件のみ失敗、本件無関係）
- `npx tsc --noEmit`: 変更ハンドラに型エラーなし

## 動作確認（残）

dev tunnel が Cloudflare API 認証エラーで未起動のため、Telegram 実機での end-to-end 確認は未実施（下記参照）。ユニットテストでロジックは網羅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)