### PR TITLE
feat: メール抽出タスクを Notion サブアイテムとして登録

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | `/unblock <メール>` | 送信者のブロックを解除 |
 | URL 送信 | ページ内容を取得してタスクを抽出し Notion に登録 |
 | テキスト・転送メッセージ送信 | Claude でタスク抽出して Notion に登録 |
-| 画像送信 | Claude Vision で要約・タスク抽出 → 1タスクにまとめて Notion 登録、複数アクションはチェックリスト化、画像をページ本文に添付 |
+| 画像送信 | Claude Vision で要約・タスク抽出 → 親タスクを Notion 登録、各アクションは Notion DB のサブアイテムとして個別登録、画像をページ本文に添付 |
 
 ## Notion DB 必須プロパティ
 
@@ -86,6 +86,9 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | Status | ステータス | 未着手 / 完了 / 中止 など |
 | Source | テキスト | Gmail / Telegram / URL など |
 | SourceURL | URL | メール元タスクの Gmail リンク |
+| 親アイテム | リレーション（同DB・自己） | Notion の「サブアイテム」機能で自動生成される双方向リレーション。プロパティ名が異なる場合は環境変数 `NOTION_SUBITEM_PARENT_PROP` で上書き可能 |
+
+**サブタスク化:** メール／画像からタスクを生成する際、Claude が抽出した各アクションは親ページ本文内のチェックボックスではなく **DB のサブアイテム（独立した子ページ）** として作成され、それぞれ Due / Priority / アイコンを個別に持つ。親ページはメール件名・本文を保持。
 
 ## ファイル構成
 

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -76,6 +76,10 @@ function headers(token: string): Record<string, string> {
   };
 }
 
+function getSubitemParentProp(env: Env): string {
+  return env.NOTION_SUBITEM_PARENT_PROP ?? "親アイテム";
+}
+
 async function getDataSourceId(env: Env): Promise<string | null> {
   const cached = await env.AGENT_KV.get(DATA_SOURCE_KV_KEY);
   if (cached) return cached;
@@ -181,13 +185,7 @@ export async function uploadImageToNotion(
   }
 }
 
-export async function addTask(
-  env: Env,
-  task: TaskInput,
-  checklist?: string[],
-  bodyText?: string,
-  imageUploadId?: string,
-): Promise<string | null> {
+function buildTaskProperties(env: Env, task: TaskInput, parentPageId?: string): Record<string, unknown> {
   const properties: Record<string, unknown> = {
     "タイトル": { title: [{ text: { content: task.title } }] },
     Status: { status: { name: STATUS_PENDING } },
@@ -208,9 +206,23 @@ export async function addTask(
     properties["Priority"] = { select: { name: priority } };
   }
 
+  if (parentPageId) {
+    properties[getSubitemParentProp(env)] = { relation: [{ id: parentPageId }] };
+  }
+
+  return properties;
+}
+
+export async function addTask(
+  env: Env,
+  task: TaskInput,
+  subtasks?: ExtractedTask[],
+  bodyText?: string,
+  imageUploadId?: string,
+): Promise<string | null> {
   const body: Record<string, unknown> = {
     parent: { database_id: env.NOTION_TASKS_DB_ID },
-    properties,
+    properties: buildTaskProperties(env, task),
   };
 
   const emoji = sanitizeEmoji(task.icon);
@@ -218,17 +230,9 @@ export async function addTask(
     body.icon = { type: "emoji", emoji };
   }
 
-  const checklistBlocks = (checklist ?? []).map((item) => ({
-    object: "block",
-    type: "to_do",
-    to_do: {
-      rich_text: [{ type: "text", text: { content: item } }],
-      checked: false,
-    },
-  }));
   const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 メール本文");
   const imageBlocks = buildImageBlocks(imageUploadId);
-  const children = [...checklistBlocks, ...bodyBlocks, ...imageBlocks];
+  const children = [...bodyBlocks, ...imageBlocks];
   if (children.length) {
     body.children = children;
   }
@@ -239,6 +243,49 @@ export async function addTask(
     body: JSON.stringify(body),
   });
   if (!resp.ok) throw new Error(`Notion addTask failed: ${resp.status}`);
+  const page = await resp.json<{ id: string }>();
+  const pageId = page.id ?? null;
+
+  if (pageId && subtasks?.length) {
+    for (const sub of subtasks) {
+      await addSubtask(env, pageId, {
+        title: sub.title,
+        due: sub.due,
+        priority: sub.priority,
+        icon: sub.icon,
+        source: task.source,
+        sourceUrl: task.sourceUrl,
+      });
+    }
+  }
+
+  return pageId;
+}
+
+export async function addSubtask(
+  env: Env,
+  parentPageId: string,
+  task: TaskInput,
+): Promise<string | null> {
+  const body: Record<string, unknown> = {
+    parent: { database_id: env.NOTION_TASKS_DB_ID },
+    properties: buildTaskProperties(env, task, parentPageId),
+  };
+
+  const emoji = sanitizeEmoji(task.icon);
+  if (emoji) {
+    body.icon = { type: "emoji", emoji };
+  }
+
+  const resp = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    console.warn(`Notion addSubtask failed for parent=${parentPageId}: ${resp.status}`);
+    return null;
+  }
   const page = await resp.json<{ id: string }>();
   return page.id ?? null;
 }
@@ -328,7 +375,7 @@ export async function updateTaskDue(env: Env, pageId: string, due: string): Prom
 export async function updateTaskFromReply(
   env: Env,
   pageId: string,
-  checklist: string[],
+  subtasks: ExtractedTask[],
   priority: string,
   due: string | null,
   bodyText?: string,
@@ -345,6 +392,8 @@ export async function updateTaskFromReply(
   const currentPriority = ((props["Priority"] as Record<string, unknown> | undefined)?.select as { name: string } | undefined)?.name ?? "medium";
   const currentDueObj = (props["Due"] as Record<string, unknown> | undefined)?.date as { start: string } | undefined;
   const currentDue = currentDueObj?.start?.slice(0, 10) ?? null;
+  const sourceUrlObj = props["SourceURL"] as { url?: string } | undefined;
+  const inheritedSourceUrl = sourceUrlObj?.url ?? undefined;
 
   const updates: Record<string, unknown> = {};
 
@@ -367,22 +416,23 @@ export async function updateTaskFromReply(
     });
   }
 
-  const checklistBlocks = checklist.map((item) => ({
-    object: "block",
-    type: "to_do",
-    to_do: {
-      rich_text: [{ type: "text", text: { content: item } }],
-      checked: false,
-    },
-  }));
   const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 返信メール");
-  const appendChildren = [...checklistBlocks, ...bodyBlocks];
-
-  if (appendChildren.length) {
+  if (bodyBlocks.length) {
     await fetch(`${NOTION_API}/blocks/${pageId}/children`, {
       method: "PATCH",
       headers: headers(env.NOTION_TOKEN),
-      body: JSON.stringify({ children: appendChildren }),
+      body: JSON.stringify({ children: bodyBlocks }),
+    });
+  }
+
+  for (const sub of subtasks) {
+    await addSubtask(env, pageId, {
+      title: sub.title,
+      due: sub.due,
+      priority: sub.priority,
+      icon: sub.icon,
+      source: "Gmail",
+      sourceUrl: inheritedSourceUrl,
     });
   }
 }

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -69,21 +69,21 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
           (priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b,
         );
         const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
-        const checklist = tasks.map((t) => t.title);
+        const subtaskTitles = tasks.map((t) => t.title);
 
         const existingPageId = await getThreadMapEntry(env, threadId);
 
         if (existingPageId) {
-          await updateTaskFromReply(env, existingPageId, checklist, best.priority, dues[0] ?? null, body);
+          await updateTaskFromReply(env, existingPageId, tasks, best.priority, dues[0] ?? null, body);
           if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
           taskLines.push(
-            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  ${taskLink(existingPageId)}`,
+            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${taskLink(existingPageId)}`,
           );
         } else {
           const pageId = await addTask(
             env,
             { title: subject, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Gmail", sourceUrl: gmailUrl },
-            checklist,
+            tasks,
             body,
           );
           if (pageId) {
@@ -94,7 +94,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
           }
           const link = pageId ? taskLink(pageId) : `[📧 Gmail で開く](${gmailUrl})`;
           taskLines.push(
-            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${checklist.map(escapeMd).join("、")}\n  ${link}`,
+            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${link}`,
           );
         }
       } else {

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -225,7 +225,7 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
     uploadImageToNotion(env, imageData, mediaType, `telegram-${largest.file_id}.${ext}`),
   ]);
 
-  const checklist = tasks.map((t) => t.title);
+  const subtaskTitles = tasks.map((t) => t.title);
   const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
   const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
   const best: Pick<ExtractedTask, "priority" | "icon"> = tasks.length
@@ -236,14 +236,14 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
   const id = await addTask(
     env,
     { title, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Telegram" },
-    checklist,
+    tasks,
     undefined,
     uploadId ?? undefined,
   );
   if (id) await syncTaskCalendarEventSafe(env, { pageId: id, title, due: dues[0] ?? null });
 
   const lines = [`✅ タスクを登録しました`, ``, `*${title}*`];
-  if (checklist.length) lines.push(...checklist.map((t) => `• ${t}`));
+  if (subtaskTitles.length) lines.push(...subtaskTitles.map((t) => `• ${t}`));
   if (!uploadId) lines.push(``, `⚠️ 画像のアップロードに失敗したためテキストのみ登録`);
   if (id) lines.push(``, taskLink(id));
   await sendMessage(env, lines.join("\n"));

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -17,6 +17,7 @@ export interface Env {
   COST_REPORT_HOUR?: string;
   GMAIL_TASK_LABEL?: string;
   GMAIL_ACCOUNT_INDEX?: string;
+  NOTION_SUBITEM_PARENT_PROP?: string;
 }
 
 export interface Task {

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { addTask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, sanitizeEmoji } from "../../../src/clients/notion.js";
+import { addTask, addSubtask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, sanitizeEmoji } from "../../../src/clients/notion.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import notionFixtures from "../../fixtures/notion-tasks.json" assert { type: "json" };
 
@@ -29,34 +29,65 @@ describe("addTask", () => {
     expect(body.properties.Due.date.start).toBe("2026-05-01");
   });
 
-  it("appends checklist as to_do blocks when provided", async () => {
+  it("creates subtask pages with parent relation when subtasks provided", async () => {
     const env = createMockEnv();
     const fetchMock = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "sub-1" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "sub-2" }), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await addTask(env, { title: "チェックリスト付き" }, ["項目1", "項目2"]);
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.children).toHaveLength(2);
-    expect(body.children[0].type).toBe("to_do");
-    expect(body.children[0].to_do.rich_text[0].text.content).toBe("項目1");
+    await addTask(env, { title: "親タスク", source: "Gmail", sourceUrl: "https://mail.google.com/x" }, [
+      { title: "項目1", priority: "high", due: "2026-05-21", icon: "📩" },
+      { title: "項目2", priority: "medium", due: null },
+    ]);
+
+    expect(fetchMock.mock.calls).toHaveLength(3);
+
+    const sub1 = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(sub1.parent.database_id).toBe(env.NOTION_TASKS_DB_ID);
+    expect(sub1.properties["タイトル"].title[0].text.content).toBe("項目1");
+    expect(sub1.properties["親アイテム"].relation[0].id).toBe("page-new-001");
+    expect(sub1.properties.Priority.select.name).toBe("high");
+    expect(sub1.properties.Due.date.start).toBe("2026-05-21");
+    expect(sub1.properties.Source.rich_text[0].text.content).toBe("Gmail");
+    expect(sub1.properties.SourceURL.url).toBe("https://mail.google.com/x");
+    expect(sub1.icon).toEqual({ type: "emoji", emoji: "📩" });
+
+    const sub2 = JSON.parse(fetchMock.mock.calls[2][1].body);
+    expect(sub2.properties["タイトル"].title[0].text.content).toBe("項目2");
+    expect(sub2.properties.Due).toBeUndefined();
   });
 
-  it("appends email body blocks after checklist when bodyText provided", async () => {
+  it("uses NOTION_SUBITEM_PARENT_PROP override when set", async () => {
+    const env = createMockEnv({ NOTION_SUBITEM_PARENT_PROP: "Parent task" });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "sub-x" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addTask(env, { title: "親", source: "Gmail" }, [
+      { title: "子", priority: "medium", due: null },
+    ]);
+    const sub = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(sub.properties["Parent task"].relation[0].id).toBe("page-new-001");
+  });
+
+  it("appends only email body blocks (no checklist) when bodyText provided", async () => {
     const env = createMockEnv();
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await addTask(env, { title: "メール本文付き" }, ["項目1"], "これはメール本文です。");
+    await addTask(env, { title: "メール本文付き" }, undefined, "これはメール本文です。");
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.children).toHaveLength(4);
-    expect(body.children[0].type).toBe("to_do");
-    expect(body.children[1].type).toBe("divider");
-    expect(body.children[2].type).toBe("heading_3");
-    expect(body.children[2].heading_3.rich_text[0].text.content).toBe("📧 メール本文");
-    expect(body.children[3].type).toBe("paragraph");
-    expect(body.children[3].paragraph.rich_text[0].text.content).toBe("これはメール本文です。");
+    expect(body.children).toHaveLength(3);
+    expect(body.children[0].type).toBe("divider");
+    expect(body.children[1].type).toBe("heading_3");
+    expect(body.children[1].heading_3.rich_text[0].text.content).toBe("📧 メール本文");
+    expect(body.children[2].type).toBe("paragraph");
+    expect(body.children[2].paragraph.rich_text[0].text.content).toBe("これはメール本文です。");
+    expect(body.children.some((b: { type: string }) => b.type === "to_do")).toBe(false);
   });
 
   it("splits long email body into multiple paragraph blocks of 2000 chars each", async () => {
@@ -66,7 +97,7 @@ describe("addTask", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const longBody = "あ".repeat(4500);
-    await addTask(env, { title: "長文メール" }, [], longBody);
+    await addTask(env, { title: "長文メール" }, undefined, longBody);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     const paragraphs = body.children.filter((b: { type: string }) => b.type === "paragraph");
     expect(paragraphs).toHaveLength(3);
@@ -82,7 +113,7 @@ describe("addTask", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const hugeBody = "x".repeat(15000);
-    await addTask(env, { title: "超長文" }, [], hugeBody);
+    await addTask(env, { title: "超長文" }, undefined, hugeBody);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     const paragraphs = body.children.filter((b: { type: string }) => b.type === "paragraph");
     const lastChunk = paragraphs[paragraphs.length - 1].paragraph.rich_text[0].text.content;
@@ -125,16 +156,51 @@ describe("addTask", () => {
     expect(id).toBe(notionFixtures.createResponse.id);
   });
 
-  it("does not append body blocks when bodyText is empty", async () => {
+  it("omits children array entirely when no body and no image", async () => {
     const env = createMockEnv();
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify(notionFixtures.createResponse), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await addTask(env, { title: "本文なし" }, ["項目1"], "");
+    await addTask(env, { title: "本文なし" }, undefined, "");
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.children).toHaveLength(1);
-    expect(body.children[0].type).toBe("to_do");
+    expect(body.children).toBeUndefined();
+  });
+});
+
+describe("addSubtask", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a DB page with parent relation set", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: "sub-page-id" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const id = await addSubtask(env, "parent-page-id", {
+      title: "サブ",
+      priority: "high",
+      due: "2026-05-21T10:30",
+      icon: "📩",
+      source: "Gmail",
+    });
+    expect(id).toBe("sub-page-id");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.properties["親アイテム"].relation).toEqual([{ id: "parent-page-id" }]);
+    expect(body.properties.Due.date.start).toBe("2026-05-21T10:30+09:00");
+    expect(body.icon).toEqual({ type: "emoji", emoji: "📩" });
+  });
+
+  it("returns null and does not throw on Notion failure", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("err", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const id = await addSubtask(env, "p", { title: "子" });
+    expect(id).toBeNull();
   });
 });
 

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -80,7 +80,7 @@ describe("checkGmail", () => {
     expect(addTask).toHaveBeenCalledWith(
       env,
       expect.objectContaining({ title: "プロジェクトの進捗確認", source: "Gmail" }),
-      ["進捗を報告する"],
+      [expect.objectContaining({ title: "進捗を報告する", priority: "high", due: "2026-04-30" })],
       "内容",
     );
     const { syncTaskCalendarEventSafe } = await import("../../../src/handlers/calendar.js");
@@ -148,7 +148,7 @@ describe("checkGmail", () => {
     expect(updateTaskFromReply).toHaveBeenCalledWith(
       env,
       "existing-page-id",
-      ["追加確認を実施する"],
+      [expect.objectContaining({ title: "追加確認を実施する", priority: "medium", due: null })],
       "medium",
       null,
       "返信内容",

--- a/cf-worker/test/unit/handlers/telegram.test.ts
+++ b/cf-worker/test/unit/handlers/telegram.test.ts
@@ -123,7 +123,11 @@ describe("handleTelegramWebhook", () => {
     expect(addTask).toHaveBeenCalledWith(
       env,
       expect.objectContaining({ title: "週末の買い物リスト", priority: "high", due: "2026-05-01", source: "Telegram" }),
-      ["牛乳を買う", "卵を買う", "パンを買う"],
+      [
+        expect.objectContaining({ title: "牛乳を買う", priority: "medium" }),
+        expect.objectContaining({ title: "卵を買う", priority: "high", due: "2026-05-01" }),
+        expect.objectContaining({ title: "パンを買う", priority: "low" }),
+      ],
       undefined,
       "upload-id-001",
     );


### PR DESCRIPTION
## Summary
- メール／画像から抽出した各アクションを、親ページ内の to_do チェックボックスではなく **Notion DB のサブアイテム（独立した子ページ）** として登録するように変更
- 各サブタスクは Due / Priority / アイコンを個別に持ち、Notion ネイティブの「サブアイテム」機能で親と紐付く
- 親relationプロパティ名は `NOTION_SUBITEM_PARENT_PROP` で上書き可能（既定: `親アイテム`）

## 変更
- `addTask`: 3rd 引数を `checklist: string[]` → `subtasks: ExtractedTask[]` に変更し、to_do ブロック生成を廃止
- `addSubtask`: 新規追加。親relation付きで DB ページを作成
- `updateTaskFromReply`: 返信メールでも子ページとしてサブタスクを追加（メール本文ブロックは引き続き親に追記）
- `gmail.ts` / `telegram.ts`（画像）: 抽出 task[] をそのまま subtasks として渡す
- README: 「親アイテム」relation を必須プロパティに追記、サブタスク仕様を記載

## Notion 側の前提
- タスク DB に Notion 公式「サブアイテム」機能（自己リレーション）が設定済みであること
- プロパティ名が `親アイテム` 以外の場合は `NOTION_SUBITEM_PARENT_PROP` 環境変数で指定

## Test plan
- [x] `npm test` で notion / gmail / telegram のユニット・統合テストが緑（事前から失敗している task-formatter のタイムゾーン依存3件は無関係）
- [ ] 本番デプロイ後、未読メール1通でサブアイテム作成・親relation設定を Notion 上で確認
- [ ] 同スレッドの返信メールで既存ページに子ページが追加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)