### PR TITLE
feat: 日次ブリーフィングを読みやすい構造化フォーマットに変更

### DIFF
--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -202,7 +202,7 @@ export async function summarizeDay(
   const tasksText = tasks.map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"})`).join("\n") || "（なし）";
   const overdueText = overdueTasks.map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? ""})`).join("\n") || "（なし）";
 
-  const prompt = `今日の予定とタスクをもとに、簡潔な日次ブリーフィングを日本語で作成してください。
+  const prompt = `今日の予定とタスクをもとに、ユーザーへの短いコメントを日本語で作成してください。
 
 ## 今日の予定
 ${eventsText}
@@ -213,7 +213,11 @@ ${tasksText}
 ## 期限切れタスク
 ${overdueText}
 
-ブリーフィングは3〜5文程度にまとめてください。期限切れタスクがある場合は必ず言及してください。`;
+## 出力ルール
+- 予定とタスクの具体的なリストは別途表示するので、ここでは羅列しない
+- 全体感（忙しさ・優先すべきポイント・期限切れの注意喚起など）を 1〜2 文で簡潔に
+- 期限切れタスクがある場合は必ず触れる
+- 装飾やマークダウン記号は使わず、プレーンな文章のみ`;
 
   return callClaude(env, "summarize_day", "", prompt, 512);
 }

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -1,4 +1,4 @@
-import type { Env } from "../types.js";
+import type { Env, CalendarEvent, Task } from "../types.js";
 import { getTodaysEvents } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
 import { summarizeDay } from "../clients/anthropic.js";
@@ -21,6 +21,53 @@ function jstDateStr(): string {
   }).replace(/\//g, "-");
 }
 
+function formatEventTime(start: string): string {
+  if (!start.includes("T")) return "終日";
+  return new Date(start).toLocaleTimeString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function formatDueShort(due: string | null): string {
+  if (!due) return "";
+  const [, m, d] = due.slice(0, 10).split("-");
+  return `${parseInt(m, 10)}/${parseInt(d, 10)}`;
+}
+
+function formatEventsSection(events: CalendarEvent[]): string {
+  if (!events.length) return "*🗓 今日の予定*\n（なし）";
+  const lines = events.map((e) => `• ${formatEventTime(e.start)} ${e.summary || "(タイトルなし)"}`);
+  return `*🗓 今日の予定 (${events.length}件)*\n${lines.join("\n")}`;
+}
+
+function formatOverdueSection(overdue: Task[]): string {
+  if (!overdue.length) return "";
+  const icon = { high: "🔴", medium: "🟡", low: "🟢" } as const;
+  const lines = overdue.map((t) => `• ${icon[t.priority]} ${t.title} (${formatDueShort(t.due)})`);
+  return `*⚠️ 期限切れ (${overdue.length}件)*\n${lines.join("\n")}`;
+}
+
+function formatTasksSection(tasks: Task[]): string {
+  if (!tasks.length) return "*✅ 未完了タスク*\n（なし）";
+  const grouped: Record<"high" | "medium" | "low", Task[]> = { high: [], medium: [], low: [] };
+  for (const t of tasks) grouped[t.priority].push(t);
+
+  const labels = { high: "🔴 *High*", medium: "🟡 *Medium*", low: "🟢 *Low*" } as const;
+  const lines: string[] = [];
+  for (const p of ["high", "medium", "low"] as const) {
+    if (!grouped[p].length) continue;
+    lines.push(labels[p]);
+    for (const t of grouped[p]) {
+      const due = t.due ? ` (〜${formatDueShort(t.due)})` : "";
+      lines.push(`• ${t.title}${due}`);
+    }
+  }
+  return `*✅ 未完了タスク (${tasks.length}件)*\n${lines.join("\n")}`;
+}
+
 export async function sendDailyBriefing(env: Env): Promise<void> {
   const [events, tasks] = await Promise.all([getTodaysEvents(env), getOpenTasks(env)]);
 
@@ -28,10 +75,20 @@ export async function sendDailyBriefing(env: Env): Promise<void> {
     .toISOString()
     .slice(0, 10);
   const overdue = tasks.filter((t) => t.due && t.due.slice(0, 10) < todayStr);
+  const openTasks = tasks.filter((t) => !overdue.includes(t));
 
-  const summary = await summarizeDay(env, events, tasks, overdue);
+  const summary = await summarizeDay(env, events, openTasks, overdue);
   const dateStr = jstDateStr();
-  await sendMessage(env, `*📅 日次ブリーフィング ${dateStr}*\n\n${summary}`);
+
+  const sections = [
+    `*📅 日次ブリーフィング ${dateStr}*`,
+    summary.trim(),
+    formatEventsSection(events),
+    formatOverdueSection(overdue),
+    formatTasksSection(openTasks),
+  ].filter(Boolean);
+
+  await sendMessage(env, sections.join("\n\n"));
 }
 
 export async function sendCostReport(env: Env): Promise<void> {


### PR DESCRIPTION
## Summary
- 日次ブリーフィングを Claude による単一段落から、セクション分けされた構造化メッセージに変更
- 予定・期限切れ・未完了タスクをそれぞれセクション化し、優先度別にグルーピング
- Claude には平文 1〜2 文の総評コメントだけを生成させ、リストはコード側で整形（出力ブレを防止）

## Before / After

Before（改行なしの段落）:
```
*📅 日次ブリーフィング 2026-05-21*

今日は会議が3件あり予定が詰まっています。期限切れタスクが2件あるので午前中に対応しましょう。
```

After（構造化）:
```
*📅 日次ブリーフィング 2026-05-21*

今日は予定が詰まっています。期限切れタスクが2件あるので午前中に対応しましょう。

*🗓 今日の予定 (3件)*
• 09:00 朝ミーティング
• 14:00 ジム
• 19:00 夕食

*⚠️ 期限切れ (2件)*
• 🔴 レポート提出 (5/18)
• 🟡 請求書確認 (5/19)

*✅ 未完了タスク (4件)*
🔴 *High*
• 顧客提案書（〜5/22）
🟡 *Medium*
• 議事録作成
🟢 *Low*
• 書類整理
```

## Test plan
- [ ] 次回 23:00 JST の cron 実行（または手動 trigger）で Telegram に届くメッセージが上記フォーマットになることを確認
- [ ] イベント0件/タスク0件/期限切れ0件のいずれかが欠けても崩れないこと
- [ ] 期限切れがある場合、Claude のコメントで必ず触れられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)