### PR TITLE
fix: 日次ブリーフィングの Telegram Markdown パースエラーを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ ambient-agent/
 │   │   └── storage/              # D1・KV アクセス層
 │   │       ├── d1.ts             # D1 CRUD ヘルパー
 │   │       └── kv.ts             # KV ヘルパー
-│   ├── test/                     # Vitest テスト（84件）
+│   ├── test/                     # Vitest テスト（134件）
 │   ├── migrations/               # D1 スキーマ
 │   ├── scripts/
 │   │   ├── push-secrets.mjs       # Worker Secrets 一括登録

--- a/cf-worker/src/clients/telegram.ts
+++ b/cf-worker/src/clients/telegram.ts
@@ -6,6 +6,16 @@ function apiUrl(token: string, method: string): string {
   return `https://api.telegram.org/bot${token}/${method}`;
 }
 
+function postMessage(env: Env, url: string, text: string, parseMode?: "Markdown"): Promise<Response> {
+  const payload: Record<string, unknown> = { chat_id: env.TELEGRAM_CHAT_ID, text };
+  if (parseMode) payload.parse_mode = parseMode;
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
 export async function sendMessage(env: Env, text: string): Promise<void> {
   const url = apiUrl(env.TELEGRAM_BOT_TOKEN, "sendMessage");
   const chunks: string[] = [];
@@ -13,19 +23,20 @@ export async function sendMessage(env: Env, text: string): Promise<void> {
     chunks.push(text.slice(i, i + MAX_LENGTH));
   }
   for (const chunk of chunks) {
-    const resp = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        chat_id: env.TELEGRAM_CHAT_ID,
-        text: chunk,
-        parse_mode: "Markdown",
-      }),
-    });
-    if (!resp.ok) {
-      const body = await resp.text();
-      throw new Error(`Telegram sendMessage failed: ${resp.status} ${body}`);
+    const resp = await postMessage(env, url, chunk, "Markdown");
+    if (resp.ok) continue;
+
+    const body = await resp.text();
+    // レガシー Markdown はエスケープ漏れ 1 文字で 400 になる。
+    // パース失敗時は parse_mode なし（プレーンテキスト）で再送し、配信を死守する。
+    if (resp.status === 400 && body.includes("can't parse entities")) {
+      console.error(`Telegram Markdown parse failed, retrying as plain text: ${body}`);
+      const retry = await postMessage(env, url, chunk);
+      if (retry.ok) continue;
+      const retryBody = await retry.text();
+      throw new Error(`Telegram sendMessage failed (plain retry): ${retry.status} ${retryBody}`);
     }
+    throw new Error(`Telegram sendMessage failed: ${resp.status} ${body}`);
   }
 }
 

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -2,7 +2,7 @@ import type { Env, CalendarEvent, Task } from "../types.js";
 import { getTodaysEvents } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
 import { summarizeDay } from "../clients/anthropic.js";
-import { sendMessage } from "../clients/telegram.js";
+import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { getDailyUsage, takeEmailDigest } from "../storage/kv.js";
 
 const PRICE_INPUT_PER_M = 0.8;
@@ -39,14 +39,16 @@ function formatDueShort(due: string | null): string {
 
 function formatEventsSection(events: CalendarEvent[]): string {
   if (!events.length) return "*🗓 今日の予定*\n（なし）";
-  const lines = events.map((e) => `• ${formatEventTime(e.start)} ${e.summary || "(タイトルなし)"}`);
+  const lines = events.map(
+    (e) => `• ${formatEventTime(e.start)} ${e.summary ? escapeMd(e.summary) : "(タイトルなし)"}`,
+  );
   return `*🗓 今日の予定 (${events.length}件)*\n${lines.join("\n")}`;
 }
 
 function formatOverdueSection(overdue: Task[]): string {
   if (!overdue.length) return "";
   const icon = { high: "🔴", medium: "🟡", low: "🟢" } as const;
-  const lines = overdue.map((t) => `• ${icon[t.priority]} ${t.title} (${formatDueShort(t.due)})`);
+  const lines = overdue.map((t) => `• ${icon[t.priority]} ${escapeMd(t.title)} (${formatDueShort(t.due)})`);
   return `*⚠️ 期限切れ (${overdue.length}件)*\n${lines.join("\n")}`;
 }
 
@@ -62,7 +64,7 @@ function formatTasksSection(tasks: Task[]): string {
     lines.push(labels[p]);
     for (const t of grouped[p]) {
       const due = t.due ? ` (〜${formatDueShort(t.due)})` : "";
-      lines.push(`• ${t.title}${due}`);
+      lines.push(`• ${escapeMd(t.title)}${due}`);
     }
   }
   return `*✅ 未完了タスク (${tasks.length}件)*\n${lines.join("\n")}`;
@@ -82,7 +84,7 @@ export async function sendDailyBriefing(env: Env): Promise<void> {
 
   const sections = [
     `*📅 日次ブリーフィング ${dateStr}*`,
-    summary.trim(),
+    escapeMd(summary.trim()),
     formatEventsSection(events),
     formatOverdueSection(overdue),
     formatTasksSection(openTasks),

--- a/cf-worker/src/handlers/calendar.ts
+++ b/cf-worker/src/handlers/calendar.ts
@@ -1,7 +1,7 @@
 import type { Env, Task } from "../types.js";
 import { getTodaysEvents, insertEvent, deleteEvent } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
-import { sendMessage } from "../clients/telegram.js";
+import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { formatTaskList, fmtDue } from "./task-formatter.js";
 import { getCalendarSync, setCalendarSync, deleteCalendarSync, getAllCalendarSync } from "../storage/d1.js";
 
@@ -104,10 +104,14 @@ export async function sendDueSoonNotice(env: Env): Promise<void> {
 
   const sections: string[] = [];
   if (dueToday.length) {
-    sections.push(`*📅 今日期限 (${dueToday.length}件)*\n` + dueToday.map((t) => `• ${t.title}`).join("\n"));
+    sections.push(
+      `*📅 今日期限 (${dueToday.length}件)*\n` + dueToday.map((t) => `• ${escapeMd(t.title)}`).join("\n"),
+    );
   }
   if (dueTomorrow.length) {
-    sections.push(`*📅 明日期限 (${dueTomorrow.length}件)*\n` + dueTomorrow.map((t) => `• ${t.title}`).join("\n"));
+    sections.push(
+      `*📅 明日期限 (${dueTomorrow.length}件)*\n` + dueTomorrow.map((t) => `• ${escapeMd(t.title)}`).join("\n"),
+    );
   }
   await sendMessage(env, "*⏰ 期限間近タスク*\n\n" + sections.join("\n\n"));
 }

--- a/cf-worker/src/handlers/escalation.ts
+++ b/cf-worker/src/handlers/escalation.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types.js";
 import { getOpenTasks, escalatePriorityTasks } from "../clients/notion.js";
-import { sendMessage } from "../clients/telegram.js";
+import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { fmtDue } from "./task-formatter.js";
 
 const STALE_DAYS = 14;
@@ -9,7 +9,7 @@ export async function sendEscalationNotice(env: Env): Promise<void> {
   const escalated = await escalatePriorityTasks(env);
   if (!escalated.length) return;
 
-  const lines = escalated.map((t) => `• ${t.title}（期限: ${fmtDue(t.due)}）`);
+  const lines = escalated.map((t) => `• ${escapeMd(t.title)}（期限: ${fmtDue(t.due)}）`);
   await sendMessage(
     env,
     `*⬆️ 優先度を high に昇格しました (${escalated.length}件)*\n\n` + lines.join("\n"),
@@ -26,7 +26,7 @@ export async function sendStaleTasksNotice(env: Env): Promise<void> {
   const stale = tasks.filter((t) => t.lastEdited && t.lastEdited <= cutoffStr);
   if (!stale.length) return;
 
-  const lines = stale.map((t) => `• ${t.title}（最終更新: ${t.lastEdited}）`);
+  const lines = stale.map((t) => `• ${escapeMd(t.title)}（最終更新: ${t.lastEdited}）`);
   await sendMessage(
     env,
     `*🕰 長期未更新タスク (${stale.length}件)*\n\n` +

--- a/cf-worker/src/handlers/task-formatter.ts
+++ b/cf-worker/src/handlers/task-formatter.ts
@@ -1,4 +1,5 @@
 import type { Task } from "../types.js";
+import { escapeMd } from "../clients/telegram.js";
 
 const TASK_APP_URL = "https://todo.eh6gac4.work";
 
@@ -68,9 +69,11 @@ export function formatTaskList(tasks: Task[], numbered = false): string {
     const due = t.due ? `（${fmtDue(t.due)}）` : "";
     const icon = PRIORITY_LABELS[t.priority] ?? "";
     const prefix = numbered ? `${i + 1}. ` : "• ";
+    // escapeMd は \ * _ ` [ を処理する。リンクテキスト内は ] も閉じ括弧扱いになるため追加でエスケープ。
+    const safeTitle = escapeMd(t.title);
     const titleLink = t.pageId
-      ? `[${t.title.replaceAll("[", "\\[").replaceAll("]", "\\]")}](${TASK_APP_URL}/?task=${t.pageId})`
-      : t.title;
+      ? `[${safeTitle.replaceAll("]", "\\]")}](${TASK_APP_URL}/?task=${t.pageId})`
+      : safeTitle;
     lines.push(`${prefix}${icon} ${titleLink}${due}`);
   }
   return lines.join("\n");

--- a/cf-worker/test/unit/clients/telegram.test.ts
+++ b/cf-worker/test/unit/clients/telegram.test.ts
@@ -56,4 +56,53 @@ describe("sendMessage", () => {
 
     await expect(sendMessage(env, "test")).rejects.toThrow("401");
   });
+
+  it("retries as plain text when Markdown parsing fails", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: false, error_code: 400, description: "Bad Request: can't parse entities" }),
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendMessage(env, "壊れた *Markdown");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const retryBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(firstBody.parse_mode).toBe("Markdown");
+    // 再送はプレーンテキスト（parse_mode なし）で、本文はそのまま届く
+    expect(retryBody.parse_mode).toBeUndefined();
+    expect(retryBody.text).toBe("壊れた *Markdown");
+  });
+
+  it("does not retry on non-parse 400 errors", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ description: "Bad Request: chat not found" }), { status: 400 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(sendMessage(env, "test")).rejects.toThrow("chat not found");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the plain-text retry also fails", async () => {
+    const env = createMockEnv();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ description: "can't parse entities" }), { status: 400 }),
+      )
+      .mockResolvedValueOnce(new Response("Internal Server Error", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(sendMessage(env, "test")).rejects.toThrow("plain retry");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/cf-worker/test/unit/handlers/briefing.test.ts
+++ b/cf-worker/test/unit/handlers/briefing.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendDailyBriefing } from "../../../src/handlers/briefing.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+
+vi.mock("../../../src/clients/gcal-api.js", () => ({
+  getTodaysEvents: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/anthropic.js", () => ({
+  summarizeDay: vi.fn(),
+}));
+
+// sendMessage のみモックし、escapeMd は実装をそのまま使う（エスケープを検証するため）
+vi.mock("../../../src/clients/telegram.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/clients/telegram.js")>()),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("sendDailyBriefing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("escapes Markdown special characters in summary, event names and task titles", async () => {
+    const env = createMockEnv();
+    const { getTodaysEvents } = await import("../../../src/clients/gcal-api.js");
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { summarizeDay } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getTodaysEvents as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { summary: "MTG_設計 *確認*", start: "2099-01-01T10:00:00+09:00" },
+    ]);
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "資料_作成 *急ぎ*", due: null, priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+    (summarizeDay as ReturnType<typeof vi.fn>).mockResolvedValue("今日は *忙しい* 一日_です");
+
+    await sendDailyBriefing(env);
+
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    // Claude サマリ・予定名・タスクタイトルがすべてエスケープされている
+    expect(sent).toContain("今日は \\*忙しい\\* 一日\\_です");
+    expect(sent).toContain("MTG\\_設計 \\*確認\\*");
+    expect(sent).toContain("資料\\_作成 \\*急ぎ\\*");
+    // ヘッダの装飾 * は素のまま（壊れていない）
+    expect(sent).toContain("*📅 日次ブリーフィング");
+  });
+
+  it("escapes overdue task titles", async () => {
+    const env = createMockEnv();
+    const { getTodaysEvents } = await import("../../../src/clients/gcal-api.js");
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { summarizeDay } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getTodaysEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "期限切れ_タスク", due: "2000-01-01", priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+    (summarizeDay as ReturnType<typeof vi.fn>).mockResolvedValue("プレーンな要約");
+
+    await sendDailyBriefing(env);
+
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(sent).toContain("期限切れ\\_タスク");
+  });
+});

--- a/cf-worker/test/unit/handlers/calendar.test.ts
+++ b/cf-worker/test/unit/handlers/calendar.test.ts
@@ -7,7 +7,9 @@ vi.mock("../../../src/clients/notion.js", () => ({
   getOpenTasks: vi.fn(),
 }));
 
-vi.mock("../../../src/clients/telegram.js", () => ({
+// sendMessage のみモックし、escapeMd は実装をそのまま使う（エスケープを検証するため）
+vi.mock("../../../src/clients/telegram.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/clients/telegram.js")>()),
   sendMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -51,6 +53,22 @@ describe("sendDueSoonNotice", () => {
     expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("今日期限タスク"));
     expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("明日期限タスク"));
     expect(sendMessage).toHaveBeenCalledWith(env, expect.not.stringContaining("来週のタスク"));
+  });
+
+  it("escapes Markdown special characters in task titles", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+    const today = now.toISOString().slice(0, 10);
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "請求書_確認 *重要*", due: today, priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await sendDueSoonNotice(env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("請求書\\_確認 \\*重要\\*"));
   });
 
   it("does not send when no tasks due soon", async () => {

--- a/cf-worker/test/unit/handlers/escalation.test.ts
+++ b/cf-worker/test/unit/handlers/escalation.test.ts
@@ -8,7 +8,9 @@ vi.mock("../../../src/clients/notion.js", () => ({
   escalatePriorityTasks: vi.fn(),
 }));
 
-vi.mock("../../../src/clients/telegram.js", () => ({
+// sendMessage のみモックし、escapeMd は実装をそのまま使う（エスケープを検証するため）
+vi.mock("../../../src/clients/telegram.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/clients/telegram.js")>()),
   sendMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -40,6 +42,19 @@ describe("sendEscalationNotice", () => {
 
     await sendEscalationNotice(env);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("escapes Markdown special characters in task titles", async () => {
+    const env = createMockEnv();
+    const { escalatePriorityTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (escalatePriorityTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "見積_資料 *至急*", due: "2026-04-27", priority: "high", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await sendEscalationNotice(env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("見積\\_資料 \\*至急\\*"));
   });
 });
 

--- a/cf-worker/test/unit/handlers/task-formatter.test.ts
+++ b/cf-worker/test/unit/handlers/task-formatter.test.ts
@@ -103,4 +103,20 @@ describe("formatTaskList", () => {
     const result = formatTaskList(tasks);
     expect(result).toContain("[タスク\\[1\\]](https://todo.eh6gac4.work/?task=abc123)");
   });
+
+  it("escapes *, _ and ` in title within link text", () => {
+    const tasks: Task[] = [
+      { title: "見積_資料 *至急*", due: null, priority: "high", status: "未着手", lastEdited: null, url: "https://notion.so/p", pageId: "abc123" },
+    ];
+    const result = formatTaskList(tasks);
+    expect(result).toContain("[見積\\_資料 \\*至急\\*](https://todo.eh6gac4.work/?task=abc123)");
+  });
+
+  it("escapes special characters in plain title when pageId is empty", () => {
+    const tasks: Task[] = [
+      { title: "メモ_確認", due: null, priority: "medium", status: "未着手", lastEdited: null, url: "", pageId: "" },
+    ];
+    const result = formatTaskList(tasks);
+    expect(result).toContain("メモ\\_確認");
+  });
 });


### PR DESCRIPTION
## 概要

本番の日次ブリーフィングが失敗していた件の調査・修正。

```
⚠️ Ambient Agent エラー
Job: 50 22 * * *  → Telegram sendMessage failed: 400 ... can't parse entities (byte offset 61)
Job: 0 23 * * *   → Telegram sendMessage failed: 400 ... can't parse entities (byte offset 478)
```

## 原因

`sendMessage` は常に `parse_mode: "Markdown"`（レガシー Markdown）を付けるが、**動的コンテンツをエスケープせず**埋め込んでいた。レガシー Markdown は対になっていない `*` `_` `` ` `` `[` が1個あるだけでパースに失敗する。

- `50 22`（07:50）= `morningPrep` → `sendEscalationNotice`。byte offset 61 はちょうど `t.title`（タスクタイトル）の先頭。タイトルに特殊文字が入って破綻。
- `0 23`（08:00）= `morningBriefing` → `sendDailyBriefing`。Claude 生成サマリ・予定名・タスクタイトルがいずれも未エスケープ。

`escapeMd` 関数は存在するのに `gmail.ts` でしか使われておらず、briefing / escalation / calendar 系は生のまま埋め込んでいた。

## 修正

- **安全網**: `sendMessage` に「Markdown パース失敗（400 `can't parse entities`）時は `parse_mode` なし（プレーンテキスト）で再送」するフォールバックを追加。これで整形が崩れても配信は死守される。
- **エスケープ**: `briefing.ts` / `escalation.ts` / `calendar.ts` / `task-formatter.ts` の動的コンテンツ（タスクタイトル・予定名・Claude サマリ）を `escapeMd` でエスケープ。`task-formatter` のリンクテキストは `*` `_` `` ` `` も未エスケープだったため併せて修正。

## テスト

今回の修正に対するユニットテストを追加:
- `telegram.test.ts`: パース失敗時のプレーンテキスト再送 / 非パース400は再送しない / 再送も失敗したら throw
- `escalation.test.ts` `calendar.test.ts` `task-formatter.test.ts`: 動的コンテンツのエスケープ検証
- `briefing.test.ts`（新規）: 日次ブリーフィングのサマリ・予定名・タスクタイトルのエスケープ検証

`TZ=UTC npm test`（CI と同環境）で全 134 件パス。

> 補足: ローカル機（JST 以外で動く Workers プール）では既存の `fmtDue` 時刻依存テスト3件が落ちるが、本修正とは無関係・CI（UTC）では緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)