### PR TITLE
feat: メールダイジェストのタスク登録通知を件数のみに簡素化

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 - morning_prep の同期は補完用。重複防止は D1 `calendar_sync` で行い、dedup キーは「期日時刻」単位（同一日付で時刻だけ変わっても反映）
 
 **morning_briefing の詳細:**
-- 直近 24 時間に hourly_gmail が処理したメールをまとめて1通の「📧 メール処理サマリ」として Telegram 送信
+- 直近 24 時間に hourly_gmail が処理したメールをまとめて1通の「📧 メール処理サマリ」として Telegram 送信（タスク登録は件数のみ＋ダッシュボードリンク、アーカイブは件名一覧）
 
 ## Telegram コマンド
 

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -140,7 +140,11 @@ export async function sendEmailDigest(env: Env): Promise<void> {
   if (!taskLines.length && !archivedLines.length) return;
 
   const sections: string[] = [];
-  if (taskLines.length) sections.push("✅ *タスク登録*\n" + taskLines.join("\n"));
+  if (taskLines.length) {
+    sections.push(
+      `✅ *タスク登録*: ${taskLines.length}件\n[🔗 ダッシュボードで確認](https://todo.eh6gac4.work)`,
+    );
+  }
   if (archivedLines.length) sections.push("📦 *アーカイブ済み*\n" + archivedLines.join("\n"));
   await sendMessage(env, "*📧 メール処理サマリ*\n\n" + sections.join("\n\n"));
 }

--- a/cf-worker/test/unit/handlers/briefing.test.ts
+++ b/cf-worker/test/unit/handlers/briefing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendDailyBriefing } from "../../../src/handlers/briefing.js";
+import { sendDailyBriefing, sendEmailDigest } from "../../../src/handlers/briefing.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 
 vi.mock("../../../src/clients/gcal-api.js", () => ({
@@ -12,6 +12,11 @@ vi.mock("../../../src/clients/notion.js", () => ({
 
 vi.mock("../../../src/clients/anthropic.js", () => ({
   summarizeDay: vi.fn(),
+}));
+
+vi.mock("../../../src/storage/kv.js", () => ({
+  takeEmailDigest: vi.fn(),
+  getDailyUsage: vi.fn(),
 }));
 
 // sendMessage のみモックし、escapeMd は実装をそのまま使う（エスケープを検証するため）
@@ -68,5 +73,92 @@ describe("sendDailyBriefing", () => {
 
     const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
     expect(sent).toContain("期限切れ\\_タスク");
+  });
+});
+
+describe("sendEmailDigest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays count and dashboard link only — no per-task details", async () => {
+    const env = createMockEnv();
+    const { takeEmailDigest } = await import("../../../src/storage/kv.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (takeEmailDigest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      taskLines: [
+        "• *会議の準備*\n  会議資料を作成\n  → 資料作成、レビュー依頼\n  [🔗 アプリで開く](https://todo.eh6gac4.work/?task=p1)",
+        "• *レポート提出*\n  週次レポート\n  → 提出\n  [🔗 アプリで開く](https://todo.eh6gac4.work/?task=p2)",
+        "• *コードレビュー*\n  PR レビュー\n  → 確認\n  [🔗 アプリで開く](https://todo.eh6gac4.work/?task=p3)",
+      ],
+      archivedLines: [],
+    });
+
+    await sendEmailDigest(env);
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(sent).toContain("✅ *タスク登録*: 3件");
+    expect(sent).toContain("[🔗 ダッシュボードで確認](https://todo.eh6gac4.work)");
+    // 個別タスクの件名やサブタスクが含まれていないこと
+    expect(sent).not.toContain("会議の準備");
+    expect(sent).not.toContain("レポート提出");
+    expect(sent).not.toContain("コードレビュー");
+    // アーカイブセクションは出さない
+    expect(sent).not.toContain("アーカイブ済み");
+  });
+
+  it("shows only archive section when no tasks were registered", async () => {
+    const env = createMockEnv();
+    const { takeEmailDigest } = await import("../../../src/storage/kv.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (takeEmailDigest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      taskLines: [],
+      archivedLines: ["• *通知メール*\n  自動通知", "• *ニュースレター*\n  購読しているメルマガ"],
+    });
+
+    await sendEmailDigest(env);
+
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(sent).not.toContain("✅ *タスク登録*");
+    expect(sent).toContain("📦 *アーカイブ済み*");
+    expect(sent).toContain("通知メール");
+    expect(sent).toContain("ニュースレター");
+  });
+
+  it("includes both sections in order when tasks and archives coexist", async () => {
+    const env = createMockEnv();
+    const { takeEmailDigest } = await import("../../../src/storage/kv.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (takeEmailDigest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      taskLines: ["• *仕事メール*\n  ..."],
+      archivedLines: ["• *通知*\n  ..."],
+    });
+
+    await sendEmailDigest(env);
+
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const taskIdx = sent.indexOf("✅ *タスク登録*: 1件");
+    const archiveIdx = sent.indexOf("📦 *アーカイブ済み*");
+    expect(taskIdx).toBeGreaterThan(-1);
+    expect(archiveIdx).toBeGreaterThan(taskIdx);
+  });
+
+  it("does not send a message when digest is empty", async () => {
+    const env = createMockEnv();
+    const { takeEmailDigest } = await import("../../../src/storage/kv.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (takeEmailDigest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      taskLines: [],
+      archivedLines: [],
+    });
+
+    await sendEmailDigest(env);
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- 朝 08:00 JST のメール処理サマリ（`sendEmailDigest`）の「✅ タスク登録」セクションを、個別タスク一覧から **件数 + ダッシュボードリンク** に変更
- 「📦 アーカイブ済み」セクション・即時 Telegram 通知（テキスト/URL/画像）は現状維持
- ユーザーはタスクの中身を [todo.eh6gac4.work](https://todo.eh6gac4.work) で直接確認できるため、Telegram メッセージを軽量化

変更後の通知例:
```
*📧 メール処理サマリ*

✅ *タスク登録*: 3件
[🔗 ダッシュボードで確認](https://todo.eh6gac4.work)

📦 *アーカイブ済み*
• *通知メール*
  自動通知
```

KV スキーマ (`EmailDigest.taskLines: string[]`) は変更せず、表示層でのみ件数化（ロールバック容易）。

## Test plan

- [x] `sendEmailDigest` のユニットテストを 4 ケース追加（タスクのみ / アーカイブのみ / 両方 / 両方空）
- [x] `npx vitest run test/unit/handlers/briefing.test.ts` → 6/6 pass
- [ ] デプロイ後、翌朝 08:00 JST のメール処理サマリが新フォーマットで届くことを確認

NOTE: 既存の `task-formatter.test.ts` に 3 件の失敗（明日/明後日の日付フォーマット）がありますが、本 PR より前から存在する不具合で、本変更とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)