### PR TITLE
feat(gmail): hourly_gmail のタスク名わかりやすく＋カレンダー日時を同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 
 | 時刻 (JST) | ジョブ | 内容 |
 |---|---|---|
-| 07:30〜21:30 毎時 | hourly_gmail | Gmail 未読を少しずつサイレント処理（通知せず KV に蓄積） |
+| 07:30〜21:30 毎時 | hourly_gmail | Gmail 未読を少しずつサイレント処理（通知せず KV に蓄積） + カレンダー同期 |
 | 07:50 | morning_prep | ①ブロックリスト学習 → ②カレンダー同期 → ③優先度昇格 |
 | 08:00 | morning_briefing | ①日次ブリーフィング → ②APIコストレポート → ③期限間近通知 → ④メール処理サマリ |
 | 13:00 | task_reminder | 未着手タスク一覧を Telegram に送信 |
@@ -44,9 +44,11 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 
 **hourly_gmail の詳細:**
 - 未読メールを要約・タスク抽出し Notion に登録（返信スレッドは既存タスクを更新）
+- Notion ページのタイトルは Claude が生成する「誰から何の用件か分かる短文」を使う（メール件名そのままは避ける）
 - Telegram 通知はせず、結果を `email_digest:pending` (KV) に追記
 - Workers の subrequest 上限（無料プラン 50/呼び出し）に達したら break、未処理分は次回 cron に持ち越し
 - 個別メール処理エラーは log して続行
+- メール処理後に `syncCalendar` を実行し、Notion で編集された日時を Google Calendar へ伝播（既存イベントは PATCH で日時のみ差し替え）
 
 **morning_prep の詳細:**
 - 完了済みタスクのカレンダーイベントを削除、未着手タスクを Calendar に登録
@@ -54,7 +56,9 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 
 **カレンダー登録のタイミング:**
 - 期日付きタスクは作成時（Gmail / Telegram テキスト・画像・URL）に即座に Calendar へ登録（同日時刻指定タスクの取りこぼし防止）
-- morning_prep の同期は補完用。重複防止は D1 `calendar_sync` で行い、dedup キーは「期日時刻」単位（同一日付で時刻だけ変わっても反映）
+- 返信メールで Due が前倒しされたときも、その場で Calendar イベントを差し替える
+- hourly_gmail / morning_prep の同期は補完用。重複防止は D1 `calendar_sync` で行い、dedup キーは「期日時刻」単位（同一日付で時刻だけ変わっても反映）
+- 既存イベントの日時変更は PATCH で行い、Calendar 側に追加されたメモや出席者を保持する
 
 **morning_briefing の詳細:**
 - 直近 24 時間に hourly_gmail が処理したメールをまとめて1通の「📧 メール処理サマリ」として Telegram 送信（タスク登録は件数のみ＋ダッシュボードリンク、アーカイブは件名一覧）

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -32,12 +32,13 @@ const EXTRACT_TASKS_PROMPT = `あなたはメールからタスクを抽出す�
 
 const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタントです。
 
-以下のメールを読み、要約とアクションが必要なタスクを JSON で返してください。
+以下のメールを読み、タスク一覧で使うタイトル・要約・アクションが必要なタスクを JSON で返してください。
 
 ## 出力フォーマット（JSON のみ、説明文不要）
 
 \`\`\`json
 {
+  "task_title": "タスク一覧に並べたとき一目で内容が分かる短いタイトル（日本語・20文字程度）",
   "summary": "メールの内容を1〜2文で要約（日本語）",
   "tasks": [
     {
@@ -52,6 +53,7 @@ const ANALYZE_EMAIL_PROMPT = `あなたはメールを分析するアシスタ�
 \`\`\`
 
 ## 判断基準
+- task_title: メール件名そのままにせず、誰から何の用件かが分かる短文にする。例「件名: 【重要なお知らせ】請求書発行のご連絡」→ task_title: 「ACME社4月分請求書の支払い」。社名・人物名が分かれば含めると良い。広告・通知でタスクが無い場合は「{送信元}からのお知らせ」程度で良い
 - summary: 誰から何の用件か、重要ポイントを1〜2文で
 - tasks: 返信・確認・提出・対応などのアクション動詞を含む文をタスクとして抽出する
 - 期日が明示されていればそれを due に設定する（不明な場合は null）
@@ -123,6 +125,12 @@ export async function analyzeEmail(env: Env, subject: string, body: string): Pro
   } catch {
     return { summary: text.trim(), tasks: [] };
   }
+}
+
+/** Notion ページのタイトル候補。LLM が task_title を返さなければ件名にフォールバック。 */
+export function pickTaskTitle(analysis: EmailAnalysis, subject: string): string {
+  const t = analysis.task_title?.trim();
+  return t && t.length > 0 ? t : subject;
 }
 
 export async function extractTasksFromUrlContent(env: Env, url: string, content: string): Promise<ExtractedTask[]> {

--- a/cf-worker/src/clients/gcal-api.ts
+++ b/cf-worker/src/clients/gcal-api.ts
@@ -74,6 +74,40 @@ export async function insertEvent(env: Env, title: string, due: string): Promise
   return event.id ?? null;
 }
 
+/**
+ * 既存イベントの start/end を PATCH で書き換える。
+ * delete+insert と違い、イベント ID や追加されたメモ・出席者情報を保持できる。
+ * 404 (eventId が無効) のときだけ false を返し、呼び出し側で再作成にフォールバックさせる。
+ */
+export async function updateEventDateTime(env: Env, eventId: string, due: string): Promise<boolean> {
+  const token = await getAccessToken(env);
+
+  let body: Record<string, unknown>;
+  if (due.includes("T")) {
+    const startDt = new Date(due);
+    const endDt = new Date(startDt.getTime() + 60 * 60 * 1000);
+    body = {
+      start: { dateTime: startDt.toISOString(), timeZone: "Asia/Tokyo" },
+      end: { dateTime: endDt.toISOString(), timeZone: "Asia/Tokyo" },
+    };
+  } else {
+    body = {
+      start: { date: due },
+      end: { date: due },
+    };
+  }
+
+  const resp = await fetch(`${BASE}/events/${eventId}`, {
+    method: "PATCH",
+    headers: { ...authHeader(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (resp.status === 404 || resp.status === 410) return false;
+  if (!resp.ok) throw new Error(`updateEventDateTime failed: ${resp.status}`);
+  return true;
+}
+
 export async function deleteEvent(env: Env, eventId: string): Promise<void> {
   const token = await getAccessToken(env);
   await fetch(`${BASE}/events/${eventId}`, {

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -363,6 +363,23 @@ export async function getTaskStatus(env: Env, pageId: string): Promise<string | 
   return statusObj?.name ?? null;
 }
 
+export async function getTaskTitleAndDue(
+  env: Env,
+  pageId: string,
+): Promise<{ title: string; due: string | null } | null> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    headers: headers(env.NOTION_TOKEN),
+  });
+  if (!resp.ok) return null;
+  const page = await resp.json<{ archived?: boolean; properties?: Record<string, unknown> }>();
+  if (page.archived) return null;
+  const props = (page.properties ?? {}) as Record<string, unknown>;
+  const titleArr = ((props["タイトル"] as Record<string, unknown> | undefined)?.title as Array<{ text: { content: string } }> | undefined) ?? [];
+  const title = titleArr[0]?.text.content ?? "";
+  const dueObj = (props["Due"] as Record<string, unknown> | undefined)?.date as { start: string } | undefined;
+  return { title, due: dueObj?.start ?? null };
+}
+
 export async function updateTaskDue(env: Env, pageId: string, due: string): Promise<void> {
   const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
     method: "PATCH",

--- a/cf-worker/src/handlers/calendar.ts
+++ b/cf-worker/src/handlers/calendar.ts
@@ -1,5 +1,5 @@
 import type { Env, Task } from "../types.js";
-import { getTodaysEvents, insertEvent, deleteEvent } from "../clients/gcal-api.js";
+import { getTodaysEvents, insertEvent, deleteEvent, updateEventDateTime } from "../clients/gcal-api.js";
 import { getOpenTasks } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { formatTaskList, fmtDue } from "./task-formatter.js";
@@ -48,7 +48,18 @@ export async function syncTaskCalendarEvent(
   const record = await getCalendarSync(env, task.pageId);
   if (record && record.calendarDate === eventDue) return;
 
+  // 既存イベントがあれば PATCH で日時だけ差し替え（イベント ID と Calendar 側のメモを保持）
   if (record?.eventId) {
+    try {
+      const ok = await updateEventDateTime(env, record.eventId, eventDue);
+      if (ok) {
+        await setCalendarSync(env, task.pageId, record.eventId, eventDue);
+        return;
+      }
+    } catch (err) {
+      console.warn("updateEventDateTime failed, falling back to recreate:", err);
+    }
+    // PATCH が 404/410 や失敗のときは作り直しにフォールバック
     try {
       await deleteEvent(env, record.eventId);
     } catch {

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types.js";
 import { listAllMessages, getMessage, parseMessage, isCalendarInvite, archiveMessage, addLabel, getOrCreateLabel } from "../clients/gmail-api.js";
-import { analyzeEmail } from "../clients/anthropic.js";
-import { addTask, updateTaskFromReply, getTaskStatus } from "../clients/notion.js";
+import { analyzeEmail, pickTaskTitle } from "../clients/anthropic.js";
+import { addTask, updateTaskFromReply, getTaskStatus, getTaskTitleAndDue } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { taskLink } from "./telegram.js";
 import { syncTaskCalendarEventSafe } from "./calendar.js";
@@ -62,6 +62,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
 
       const analysis = await analyzeEmail(env, subject, body);
       const { summary, tasks } = analysis;
+      const taskTitle = pickTaskTitle(analysis, subject);
 
       if (tasks.length) {
         const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
@@ -76,13 +77,18 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
         if (existingPageId) {
           await updateTaskFromReply(env, existingPageId, tasks, best.priority, dues[0] ?? null, body);
           if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
+          // updateTaskFromReply で Due が前倒しされた場合に備えて Notion の最新値で同期
+          const latest = await getTaskTitleAndDue(env, existingPageId);
+          if (latest) {
+            await syncTaskCalendarEventSafe(env, { pageId: existingPageId, title: latest.title, due: latest.due });
+          }
           taskLines.push(
-            `• *${escapeMd(subject)}*（更新）\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${taskLink(existingPageId)}`,
+            `• *${escapeMd(taskTitle)}*（更新）\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${taskLink(existingPageId)}`,
           );
         } else {
           const pageId = await addTask(
             env,
-            { title: subject, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Gmail", sourceUrl: gmailUrl },
+            { title: taskTitle, due: dues[0] ?? null, priority: best.priority, icon: best.icon, source: "Gmail", sourceUrl: gmailUrl },
             tasks,
             body,
           );
@@ -90,15 +96,15 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
             if (threadId) await setThreadMapEntry(env, threadId, pageId);
             await setSenderForTask(env, pageId, senderEmail);
             if (taskLabelId) await addLabel(env, meta.id, taskLabelId);
-            await syncTaskCalendarEventSafe(env, { pageId, title: subject, due: dues[0] ?? null });
+            await syncTaskCalendarEventSafe(env, { pageId, title: taskTitle, due: dues[0] ?? null });
           }
           const link = pageId ? taskLink(pageId) : `[📧 Gmail で開く](${gmailUrl})`;
           taskLines.push(
-            `• *${escapeMd(subject)}*\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${link}`,
+            `• *${escapeMd(taskTitle)}*\n  ${escapeMd(summary)}\n  → ${subtaskTitles.map(escapeMd).join("、")}\n  ${link}`,
           );
         }
       } else {
-        archivedLines.push(`• *${escapeMd(subject)}*\n  ${escapeMd(summary)}`);
+        archivedLines.push(`• *${escapeMd(taskTitle)}*\n  ${escapeMd(summary)}`);
       }
 
       await archiveMessage(env, meta.id);

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -10,6 +10,13 @@ import { sendMessage } from "./clients/telegram.js";
 // 無料プランの Cron 上限（5個）に合わせて5ジョブに統合
 async function hourlyGmail(env: Env): Promise<void> {
   await checkGmail(env, { silent: true });
+  // Notion で日時が編集されたタスクをカレンダーへ反映。
+  // 失敗してもメール処理結果には影響させない。
+  try {
+    await syncCalendar(env);
+  } catch (err) {
+    console.error("hourlyGmail: syncCalendar failed:", err);
+  }
 }
 
 async function morningPrep(env: Env): Promise<void> {

--- a/cf-worker/src/types.ts
+++ b/cf-worker/src/types.ts
@@ -48,6 +48,8 @@ export interface ExtractedTask {
 
 export interface EmailAnalysis {
   summary: string;
+  /** タスク一覧に表示するための簡潔なタイトル。メール件名より要点が分かる形を期待する。 */
+  task_title?: string;
   tasks: ExtractedTask[];
 }
 

--- a/cf-worker/test/fixtures/claude-responses.json
+++ b/cf-worker/test/fixtures/claude-responses.json
@@ -12,7 +12,7 @@
     "content": [
       {
         "type": "text",
-        "text": "{\"summary\": \"田中さんからプロジェクトの進捗確認依頼。期限は4月30日。\", \"tasks\": [{\"title\": \"プロジェクト進捗を報告する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"icon\": \"📩\", \"source\": \"Gmail\"}]}"
+        "text": "{\"task_title\": \"田中さんへのプロジェクト進捗報告\", \"summary\": \"田中さんからプロジェクトの進捗確認依頼。期限は4月30日。\", \"tasks\": [{\"title\": \"プロジェクト進捗を報告する\", \"due\": \"2026-04-30\", \"priority\": \"high\", \"icon\": \"📩\", \"source\": \"Gmail\"}]}"
       }
     ],
     "usage": { "input_tokens": 200, "output_tokens": 80 }

--- a/cf-worker/test/integration/scheduled.test.ts
+++ b/cf-worker/test/integration/scheduled.test.ts
@@ -70,12 +70,14 @@ describe("scheduled handler - cron dispatch", () => {
     expect(sendEscalationNotice).toHaveBeenCalledWith(env);
   });
 
-  it("30 22-23,0-12 * * * (hourly_gmail) runs checkGmail in silent mode", async () => {
+  it("30 22-23,0-12 * * * (hourly_gmail) runs checkGmail in silent mode and syncs calendar", async () => {
     const env = createMockEnv();
     const { checkGmail } = await import("../../src/handlers/gmail.js");
+    const { syncCalendar } = await import("../../src/handlers/calendar.js");
 
     await worker.scheduled(makeScheduledEvent("30 22-23,0-12 * * *"), env);
     expect(checkGmail).toHaveBeenCalledWith(env, { silent: true });
+    expect(syncCalendar).toHaveBeenCalledWith(env);
   });
 
   it("0 23 * * * (morning_briefing) runs briefing, cost, due_soon, email_digest", async () => {

--- a/cf-worker/test/unit/clients/anthropic.test.ts
+++ b/cf-worker/test/unit/clients/anthropic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { analyzeEmail, extractTasksFromText, extractTasksFromUrlContent } from "../../../src/clients/anthropic.js";
+import { analyzeEmail, extractTasksFromText, extractTasksFromUrlContent, pickTaskTitle } from "../../../src/clients/anthropic.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import claudeFixtures from "../../fixtures/claude-responses.json" assert { type: "json" };
 
@@ -16,6 +16,7 @@ describe("analyzeEmail", () => {
 
     const result = await analyzeEmail(env, "プロジェクトの進捗確認", "内容...");
     expect(result.summary).toContain("田中さん");
+    expect(result.task_title).toBe("田中さんへのプロジェクト進捗報告");
     expect(result.tasks).toHaveLength(1);
     expect(result.tasks[0].title).toBe("プロジェクト進捗を報告する");
     expect(result.tasks[0].priority).toBe("high");
@@ -44,6 +45,22 @@ describe("analyzeEmail", () => {
     const result = await analyzeEmail(env, "件名", "本文");
     expect(result.tasks).toEqual([]);
     expect(typeof result.summary).toBe("string");
+  });
+});
+
+describe("pickTaskTitle", () => {
+  it("returns task_title when present and non-empty", () => {
+    expect(pickTaskTitle({ task_title: "ACME社4月分請求書の支払い", summary: "", tasks: [] }, "【重要】請求書発行のご案内")).toBe(
+      "ACME社4月分請求書の支払い",
+    );
+  });
+
+  it("falls back to subject when task_title is missing", () => {
+    expect(pickTaskTitle({ summary: "", tasks: [] }, "件名そのまま")).toBe("件名そのまま");
+  });
+
+  it("falls back to subject when task_title is whitespace only", () => {
+    expect(pickTaskTitle({ task_title: "   ", summary: "", tasks: [] }, "件名そのまま")).toBe("件名そのまま");
   });
 });
 

--- a/cf-worker/test/unit/handlers/calendar.test.ts
+++ b/cf-worker/test/unit/handlers/calendar.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../src/clients/gcal-api.js", () => ({
   getTodaysEvents: vi.fn().mockResolvedValue([]),
   insertEvent: vi.fn().mockResolvedValue("event-id"),
   deleteEvent: vi.fn().mockResolvedValue(undefined),
+  updateEventDateTime: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("../../../src/storage/d1.js", () => ({
@@ -130,19 +131,39 @@ describe("syncTaskCalendarEvent", () => {
     expect(setCalendarSync).not.toHaveBeenCalled();
   });
 
-  it("re-creates the event when only the time changes on the same date (dedup regression)", async () => {
+  it("PATCHes the existing event when only the time changes on the same date (preserves event metadata)", async () => {
     const env = createMockEnv();
-    const { insertEvent, deleteEvent } = await import("../../../src/clients/gcal-api.js");
+    const { insertEvent, deleteEvent, updateEventDateTime } = await import("../../../src/clients/gcal-api.js");
     const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
     // legacy row stored date-only
     (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue({
       eventId: "ev-old",
       calendarDate: "2099-05-17",
     });
+    (updateEventDateTime as ReturnType<typeof vi.fn>).mockResolvedValue(true);
 
     await syncTaskCalendarEvent(env, { pageId: "p1", title: "歯医者", due: "2099-05-17T17:00:00" });
 
-    expect(deleteEvent).toHaveBeenCalledWith(env, "ev-old");
+    expect(updateEventDateTime).toHaveBeenCalledWith(env, "ev-old", "2099-05-17T17:00:00");
+    expect(deleteEvent).not.toHaveBeenCalled();
+    expect(insertEvent).not.toHaveBeenCalled();
+    expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "ev-old", "2099-05-17T17:00:00");
+  });
+
+  it("falls back to recreate when PATCH returns false (event already gone)", async () => {
+    const env = createMockEnv();
+    const { insertEvent, deleteEvent, updateEventDateTime } = await import("../../../src/clients/gcal-api.js");
+    const { getCalendarSync, setCalendarSync } = await import("../../../src/storage/d1.js");
+    (getCalendarSync as ReturnType<typeof vi.fn>).mockResolvedValue({
+      eventId: "ev-stale",
+      calendarDate: "2099-05-17",
+    });
+    (updateEventDateTime as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await syncTaskCalendarEvent(env, { pageId: "p1", title: "歯医者", due: "2099-05-17T17:00:00" });
+
+    expect(updateEventDateTime).toHaveBeenCalledWith(env, "ev-stale", "2099-05-17T17:00:00");
+    expect(deleteEvent).toHaveBeenCalledWith(env, "ev-stale");
     expect(insertEvent).toHaveBeenCalledWith(env, "歯医者", "2099-05-17T17:00:00");
     expect(setCalendarSync).toHaveBeenCalledWith(env, "p1", "event-id", "2099-05-17T17:00:00");
   });

--- a/cf-worker/test/unit/handlers/gmail.test.ts
+++ b/cf-worker/test/unit/handlers/gmail.test.ts
@@ -15,12 +15,17 @@ vi.mock("../../../src/clients/gmail-api.js", () => ({
 
 vi.mock("../../../src/clients/anthropic.js", () => ({
   analyzeEmail: vi.fn(),
+  pickTaskTitle: (analysis: { task_title?: string }, subject: string) => {
+    const t = analysis.task_title?.trim();
+    return t && t.length > 0 ? t : subject;
+  },
 }));
 
 vi.mock("../../../src/clients/notion.js", () => ({
   addTask: vi.fn(),
   updateTaskFromReply: vi.fn(),
   getTaskStatus: vi.fn(),
+  getTaskTitleAndDue: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("../../../src/clients/telegram.js", () => ({
@@ -69,6 +74,7 @@ describe("checkGmail", () => {
       gmailUrl: "https://mail.google.com/mail/u/0/#search/rfc822msgid:",
     });
     (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      task_title: "田中さんへの進捗報告",
       summary: "進捗確認の依頼",
       tasks: [{ title: "進捗を報告する", priority: "high", due: "2026-04-30" }],
     });
@@ -79,14 +85,46 @@ describe("checkGmail", () => {
     expect(addTask).toHaveBeenCalledTimes(1);
     expect(addTask).toHaveBeenCalledWith(
       env,
-      expect.objectContaining({ title: "プロジェクトの進捗確認", source: "Gmail" }),
+      expect.objectContaining({ title: "田中さんへの進捗報告", source: "Gmail" }),
       [expect.objectContaining({ title: "進捗を報告する", priority: "high", due: "2026-04-30" })],
       "内容",
     );
     const { syncTaskCalendarEventSafe } = await import("../../../src/handlers/calendar.js");
     expect(syncTaskCalendarEventSafe).toHaveBeenCalledWith(
       env,
-      { pageId: "page-new-001", title: "プロジェクトの進捗確認", due: "2026-04-30" },
+      { pageId: "page-new-001", title: "田中さんへの進捗報告", due: "2026-04-30" },
+    );
+  });
+
+  it("falls back to email subject when LLM omits task_title", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { addTask } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry } = await import("../../../src/storage/d1.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-002", threadId: "thread-002" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.newEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "件名そのまま",
+      body: "本文",
+      senderEmail: "x@example.com",
+      threadId: "thread-002",
+      gmailUrl: "https://mail.google.com/",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "要約",
+      tasks: [{ title: "やる", priority: "medium", due: null }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (addTask as ReturnType<typeof vi.fn>).mockResolvedValue("page-fallback");
+
+    await checkGmail(env);
+    expect(addTask).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ title: "件名そのまま" }),
+      expect.anything(),
+      expect.anything(),
     );
   });
 
@@ -154,6 +192,41 @@ describe("checkGmail", () => {
       "返信内容",
     );
     expect(addTask).not.toHaveBeenCalled();
+  });
+
+  it("syncs calendar with updated due after a reply email shortens the due date", async () => {
+    const env = createMockEnv();
+    const { listAllMessages, getMessage, parseMessage } = await import("../../../src/clients/gmail-api.js");
+    const { analyzeEmail } = await import("../../../src/clients/anthropic.js");
+    const { getTaskTitleAndDue } = await import("../../../src/clients/notion.js");
+    const { getThreadMapEntry } = await import("../../../src/storage/d1.js");
+    const { syncTaskCalendarEventSafe } = await import("../../../src/handlers/calendar.js");
+
+    (listAllMessages as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: "msg-reply-due", threadId: "thread-reply" }]);
+    (getMessage as ReturnType<typeof vi.fn>).mockResolvedValue(gmailFixtures.replyEmail);
+    (parseMessage as ReturnType<typeof vi.fn>).mockReturnValue({
+      subject: "Re: 締切前倒し",
+      body: "前倒しでお願いします",
+      senderEmail: "boss@example.com",
+      threadId: "thread-reply",
+      gmailUrl: "https://mail.google.com/",
+    });
+    (analyzeEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+      summary: "締切が前倒しに",
+      tasks: [{ title: "前倒し対応", priority: "high", due: "2026-05-25" }],
+    });
+    (getThreadMapEntry as ReturnType<typeof vi.fn>).mockResolvedValue("existing-page-id");
+    (getTaskTitleAndDue as ReturnType<typeof vi.fn>).mockResolvedValue({
+      title: "プロジェクト納品",
+      due: "2026-05-25",
+    });
+
+    await checkGmail(env);
+
+    expect(syncTaskCalendarEventSafe).toHaveBeenCalledWith(
+      env,
+      { pageId: "existing-page-id", title: "プロジェクト納品", due: "2026-05-25" },
+    );
   });
 
   it("skips blocked senders", async () => {


### PR DESCRIPTION
## Summary
- `analyzeEmail` の出力に `task_title` フィールドを追加し、Notion ページのタイトルを件名そのままではなく「誰から何の用件か分かる短文」にした
- 返信メールで Due が前倒しされたケースに備え、`updateTaskFromReply` 後に Notion の最新値で `syncTaskCalendarEventSafe` を呼ぶ
- `hourly_gmail` 末尾で `syncCalendar` を呼び、Notion 側で手動編集された日時を毎時 Google Calendar へ反映
- 既存イベントの日時変更は `updateEventDateTime` (PATCH) でイベント ID を保持したまま差し替え（Calendar 側のメモや出席者が失われない）

## Test plan
- [x] `npx vitest run` 全 144 件 pass
- [ ] 本番デプロイ後、次回 hourly_gmail で Notion タイトルが要約形式になることを確認
- [ ] Notion で開いているタスクの Due を変更し、次の hourly_gmail で Google Calendar が更新されること（イベント ID 維持）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)