### PR TITLE
feat: バックログ自動昇格を morning_prep に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | 時刻 (JST) | ジョブ | 内容 |
 |---|---|---|
 | 07:30〜21:30 毎時 | hourly_gmail | Gmail 未読を少しずつサイレント処理（通知せず KV に蓄積） + カレンダー同期 |
-| 07:50 | morning_prep | ①ブロックリスト学習 → ②カレンダー同期 → ③優先度昇格 |
+| 07:50 | morning_prep | ①ブロックリスト学習 → ②カレンダー同期 → ③バックログ昇格 → ④優先度昇格 |
 | 08:00 | morning_briefing | ①日次ブリーフィング → ②APIコストレポート → ③期限間近通知 → ④メール処理サマリ |
 | 13:00 | task_reminder | 未着手タスク一覧を Telegram に送信 |
 | 月 09:00 | stale_tasks | 14日以上未更新タスクを通知 |
@@ -53,6 +53,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 **morning_prep の詳細:**
 - ブロックリスト学習: `sender_map` を走査し、ステータスが「中止」のタスクの送信者を `no_task_senders` (KV) に追加。完了済みは `sender_map` から外すだけ
 - カレンダー同期: 完了済みタスクのカレンダーイベントを削除、未着手タスクを Calendar に登録
+- バックログ昇格: 期限3日以内（過去 due 含む）の「バックログ」ステータスのタスクを「未着手」に昇格。Due 未設定のバックログは対象外
 - 優先度昇格: 期限3日以内の medium タスクを high に昇格
 
 **カレンダー登録のタイミング:**
@@ -88,7 +89,7 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | タイトル | タイトル | |
 | Due | 日付 | |
 | Priority | セレクト | high / medium / low |
-| Status | ステータス | 未着手 / 完了 / 中止 など |
+| Status | ステータス | 未着手 / 完了 / 中止 / バックログ など |
 | Source | テキスト | Gmail / Telegram / URL など |
 | SourceURL | URL | メール元タスクの Gmail リンク |
 | 親アイテム | リレーション（同DB・自己） | Notion の「サブアイテム」機能で自動生成される双方向リレーション。プロパティ名が異なる場合は環境変数 `NOTION_SUBITEM_PARENT_PROP` で上書き可能 |

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -8,6 +8,7 @@ const STATUS_PENDING = "未着手";
 const STATUS_IN_PROGRESS_GROUP = ["進行中", "確認中", "一時中断"];
 const STATUS_DONE = "完了";
 const STATUS_CANCELLED = "中止";
+const STATUS_BACKLOG = "バックログ";
 
 const EMAIL_BODY_MAX_CHARS = 10000;
 const NOTION_RICH_TEXT_MAX = 2000;
@@ -332,6 +333,34 @@ export async function escalatePriorityTasks(env: Env): Promise<Task[]> {
     escalated.push(task);
   }
   return escalated;
+}
+
+// バックログに退避してあるタスクのうち、due が今から 3 日以内 (過去 due 含む) に
+// 入っているものを未着手に昇格させる。締切のないバックログ (due=null) は対象外。
+export async function promoteBacklogTasks(env: Env): Promise<Task[]> {
+  const today = new Date();
+  const deadline = new Date(today);
+  deadline.setDate(deadline.getDate() + 3);
+  const deadlineStr = deadline.toISOString().slice(0, 10);
+
+  const result = await queryDB(env, {
+    and: [
+      { property: "Status", status: { equals: STATUS_BACKLOG } },
+      { property: "Due", date: { on_or_before: deadlineStr } },
+    ],
+  });
+
+  const promoted: Task[] = [];
+  for (const page of result.results as Record<string, unknown>[]) {
+    const task = parseTaskPage(page);
+    await fetch(`${NOTION_API}/pages/${task.pageId}`, {
+      method: "PATCH",
+      headers: headers(env.NOTION_TOKEN),
+      body: JSON.stringify({ properties: { Status: { status: { name: STATUS_PENDING } } } }),
+    });
+    promoted.push(task);
+  }
+  return promoted;
 }
 
 export async function completeTask(env: Env, pageId: string): Promise<void> {

--- a/cf-worker/src/handlers/escalation.ts
+++ b/cf-worker/src/handlers/escalation.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../types.js";
-import { getOpenTasks, escalatePriorityTasks } from "../clients/notion.js";
+import { getOpenTasks, escalatePriorityTasks, promoteBacklogTasks } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { fmtDue } from "./task-formatter.js";
 
@@ -13,6 +13,17 @@ export async function sendEscalationNotice(env: Env): Promise<void> {
   await sendMessage(
     env,
     `*⬆️ 優先度を high に昇格しました (${escalated.length}件)*\n\n` + lines.join("\n"),
+  );
+}
+
+export async function sendBacklogPromotionNotice(env: Env): Promise<void> {
+  const promoted = await promoteBacklogTasks(env);
+  if (!promoted.length) return;
+
+  const lines = promoted.map((t) => `• ${escapeMd(t.title)}（期限: ${fmtDue(t.due)}）`);
+  await sendMessage(
+    env,
+    `*📥 バックログから未着手に昇格しました (${promoted.length}件)*\n\n` + lines.join("\n"),
   );
 }
 

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -2,7 +2,7 @@ import type { Env } from "./types.js";
 import { checkGmail, learnFromCancelled } from "./handlers/gmail.js";
 import { syncCalendar, sendDueSoonNotice, sendTaskReminder } from "./handlers/calendar.js";
 import { sendDailyBriefing, sendCostReport, sendEmailDigest } from "./handlers/briefing.js";
-import { sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
+import { sendBacklogPromotionNotice, sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
 import { handleTelegramWebhook } from "./handlers/telegram.js";
 import { handleAlert } from "./handlers/alert.js";
 import { sendMessage } from "./clients/telegram.js";
@@ -22,6 +22,7 @@ async function hourlyGmail(env: Env): Promise<void> {
 async function morningPrep(env: Env): Promise<void> {
   await learnFromCancelled(env);
   await syncCalendar(env);
+  await sendBacklogPromotionNotice(env);
   await sendEscalationNotice(env);
 }
 

--- a/cf-worker/test/integration/scheduled.test.ts
+++ b/cf-worker/test/integration/scheduled.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../src/handlers/briefing.js", () => ({
 }));
 
 vi.mock("../../src/handlers/escalation.js", () => ({
+  sendBacklogPromotionNotice: vi.fn().mockResolvedValue(undefined),
   sendEscalationNotice: vi.fn().mockResolvedValue(undefined),
   sendStaleTasksNotice: vi.fn().mockResolvedValue(undefined),
 }));
@@ -58,15 +59,16 @@ describe("scheduled handler - cron dispatch", () => {
     expect(learnFromCancelled).toHaveBeenCalledWith(env);
   });
 
-  it("50 22 * * * (morning_prep) runs calendar, escalation (no gmail)", async () => {
+  it("50 22 * * * (morning_prep) runs calendar, backlog promotion, escalation (no gmail)", async () => {
     const env = createMockEnv();
     const { checkGmail } = await import("../../src/handlers/gmail.js");
     const { syncCalendar } = await import("../../src/handlers/calendar.js");
-    const { sendEscalationNotice } = await import("../../src/handlers/escalation.js");
+    const { sendBacklogPromotionNotice, sendEscalationNotice } = await import("../../src/handlers/escalation.js");
 
     await worker.scheduled(makeScheduledEvent("50 22 * * *"), env);
     expect(checkGmail).not.toHaveBeenCalled();
     expect(syncCalendar).toHaveBeenCalledWith(env);
+    expect(sendBacklogPromotionNotice).toHaveBeenCalledWith(env);
     expect(sendEscalationNotice).toHaveBeenCalledWith(env);
   });
 

--- a/cf-worker/test/unit/clients/notion.test.ts
+++ b/cf-worker/test/unit/clients/notion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { addTask, addSubtask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, sanitizeEmoji } from "../../../src/clients/notion.js";
+import { addTask, addSubtask, getOpenTasks, completeTask, cancelTask, updateTaskDue, escalatePriorityTasks, promoteBacklogTasks, sanitizeEmoji } from "../../../src/clients/notion.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import notionFixtures from "../../fixtures/notion-tasks.json" assert { type: "json" };
 
@@ -313,6 +313,60 @@ describe("escalatePriorityTasks", () => {
     const escalated = await escalatePriorityTasks(env);
     expect(escalated).toHaveLength(1);
     expect(escalated[0].title).toBe("緊急タスク");
+  });
+});
+
+describe("promoteBacklogTasks", () => {
+  it("promotes backlog tasks due within 3 days to 未着手", async () => {
+    const env = createMockEnv();
+    const today = new Date();
+    const dueSoon = new Date(today);
+    dueSoon.setDate(dueSoon.getDate() + 2);
+    const dueStr = dueSoon.toISOString().slice(0, 10);
+
+    const backlogTask = {
+      id: "page-promote",
+      url: "",
+      last_edited_time: today.toISOString(),
+      properties: {
+        "タイトル": { title: [{ text: { content: "下書きレビュー" } }] },
+        Due: { date: { start: dueStr } },
+        Priority: { select: { name: "medium" } },
+        Status: { status: { name: "バックログ" } },
+      },
+    };
+
+    const patchSpy = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ data_sources: [] }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [backlogTask] }), { status: 200 }))
+        .mockImplementation(patchSpy),
+    );
+
+    const promoted = await promoteBacklogTasks(env);
+    expect(promoted).toHaveLength(1);
+    expect(promoted[0].title).toBe("下書きレビュー");
+
+    const patchCall = patchSpy.mock.calls[0];
+    expect(patchCall[0]).toContain("page-promote");
+    expect(patchCall[1].method).toBe("PATCH");
+    expect(patchCall[1].body).toContain("未着手");
+  });
+
+  it("returns empty when no backlog tasks are eligible", async () => {
+    const env = createMockEnv();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ data_sources: [] }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 })),
+    );
+
+    const promoted = await promoteBacklogTasks(env);
+    expect(promoted).toHaveLength(0);
   });
 });
 

--- a/cf-worker/test/unit/handlers/escalation.test.ts
+++ b/cf-worker/test/unit/handlers/escalation.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendEscalationNotice, sendStaleTasksNotice } from "../../../src/handlers/escalation.js";
+import { sendBacklogPromotionNotice, sendEscalationNotice, sendStaleTasksNotice } from "../../../src/handlers/escalation.js";
 import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
 import type { Task } from "../../../src/types.js";
 
 vi.mock("../../../src/clients/notion.js", () => ({
   getOpenTasks: vi.fn(),
   escalatePriorityTasks: vi.fn(),
+  promoteBacklogTasks: vi.fn(),
 }));
 
 // sendMessage のみモックし、escapeMd は実装をそのまま使う（エスケープを検証するため）
@@ -55,6 +56,37 @@ describe("sendEscalationNotice", () => {
 
     await sendEscalationNotice(env);
     expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("見積\\_資料 \\*至急\\*"));
+  });
+});
+
+describe("sendBacklogPromotionNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends notice when backlog tasks are promoted", async () => {
+    const env = createMockEnv();
+    const { promoteBacklogTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (promoteBacklogTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "原稿チェック", due: "2026-05-27", priority: "medium", status: "未着手", lastEdited: null, url: "", pageId: "p1" },
+    ]);
+
+    await sendBacklogPromotionNotice(env);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("原稿チェック"));
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("バックログから未着手に昇格"));
+  });
+
+  it("does not send when nothing was promoted", async () => {
+    const env = createMockEnv();
+    const { promoteBacklogTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (promoteBacklogTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await sendBacklogPromotionNotice(env);
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- notion-tasks プロジェクトから cron 機能を移管
- 期限 3 日以内（過去 due 含む）の「バックログ」タスクを「未着手」に自動昇格し、Telegram で通知

## 背景
notion-tasks (eh6gac4/notion-tasks#117) で同等の cron を持っていたが、Cloudflare 無料プランのアカウント単位 cron triggers 上限 (5 個) に達し deploy が連続失敗していた。当該 cron を notion-tasks から削除済みで、ロジックを本プロジェクト (ambient-agent) の既存 `morning_prep` ジョブに統合する。

## 変更点
- `cf-worker/src/clients/notion.ts`: `STATUS_BACKLOG` 定数と `promoteBacklogTasks` を追加（既存 `escalatePriorityTasks` と同じパターン）
- `cf-worker/src/handlers/escalation.ts`: `sendBacklogPromotionNotice` を追加（昇格 0 件のときは Telegram 通知しない）
- `cf-worker/src/index.ts`: `morningPrep` に `sendBacklogPromotionNotice` を挿入（カレンダー同期と優先度昇格の間）
- README.md: スケジュール表・morning_prep 詳細・Status プロパティの記述を更新
- テスト: 単体・統合ともに追加 (148 件全てパス)

## 仕様
- 対象: `Status = "バックログ"` かつ `Due <= today + 3 days`
- アクション: `Status` を `"未着手"` に PATCH
- Due 未設定のバックログは対象外（notion-tasks 側のもとの実装と同じ）
- 過去 due (overdue) も拾う

## Test plan
- [x] `npm test` (148 passed / 16 files)
- [ ] PR マージ後の `npx wrangler deploy` が成功すること
- [ ] 翌朝 07:50 JST の morning_prep で実機の Notion DB が更新され、Telegram に通知が届くことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)