### PR TITLE
feat(gmail): HTMLメール本文のフォールバック抽出に対応

### DIFF
--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -41,20 +41,59 @@ function decodeBase64Url(data: string): string {
   return UTF8_DECODER.decode(bytes);
 }
 
-function extractBody(payload: GmailPayload): string {
-  if (payload.mimeType === "text/plain") {
-    const data = payload.body?.data ?? "";
-    if (!data) return "";
-    try {
-      return decodeBase64Url(data);
-    } catch {
-      return "";
-    }
+function decodePart(payload: GmailPayload): string {
+  const data = payload.body?.data ?? "";
+  if (!data) return "";
+  try {
+    return decodeBase64Url(data);
+  } catch {
+    return "";
   }
+}
+
+// MIME ツリーを再帰的に探索し、最初に見つかった指定 mimeType パートの本文を返す。
+function extractByMime(payload: GmailPayload, mimeType: string): string {
+  if (payload.mimeType === mimeType) return decodePart(payload);
   for (const part of payload.parts ?? []) {
-    const result = extractBody(part);
+    const result = extractByMime(part, mimeType);
     if (result) return result;
   }
+  return "";
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+};
+
+// HTML 本文を LLM に渡せるプレーンテキストへ簡易変換する。
+// Workers 環境では cheerio/jsdom が重いため、正規表現ベースの軽量ストリッパで処理する。
+function stripHtml(html: string): string {
+  return html
+    .replace(/<(script|style|head)[^>]*>[\s\S]*?<\/\1>/gi, "") // 不可視ブロックを除去
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|tr|li|h[1-6]|table)>/gi, "\n") // ブロック要素末尾を改行に
+    .replace(/<[^>]+>/g, "") // 残りのタグを除去
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&[a-z]+;/gi, (m) => HTML_ENTITIES[m.toLowerCase()] ?? m)
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// text/plain を優先し、無ければ text/html をタグ除去してフォールバックする。
+function extractBody(payload: GmailPayload): string {
+  const plain = extractByMime(payload, "text/plain");
+  if (plain) return plain;
+  const html = extractByMime(payload, "text/html");
+  if (html) return stripHtml(html);
   return "";
 }
 

--- a/cf-worker/test/unit/clients/gmail-api.test.ts
+++ b/cf-worker/test/unit/clients/gmail-api.test.ts
@@ -77,6 +77,78 @@ describe("parseMessage body decoding", () => {
     expect(parseMessage(msg as never).body).toBe(body);
   });
 
+  it("falls back to text/html (tag-stripped) when no text/plain part exists", () => {
+    const html =
+      "<html><head><style>p{color:red}</style></head><body>" +
+      "<p>請求書の件です。</p><div>支払期限は&nbsp;6/30&nbsp;まで&amp;要確認。</div>" +
+      "<br>よろしくお願いします。</body></html>";
+    const msg = {
+      id: "m5",
+      threadId: "t5",
+      payload: {
+        mimeType: "multipart/alternative",
+        headers: [
+          { name: "Subject", value: "請求書" },
+          { name: "From", value: "biller <b@example.com>" },
+        ],
+        parts: [
+          {
+            mimeType: "text/html",
+            headers: [{ name: "Content-Type", value: "text/html; charset=UTF-8" }],
+            body: { data: utf8B64Url(html) },
+          },
+        ],
+      },
+    };
+    const parsed = parseMessage(msg as never);
+    expect(parsed.body).toBe("請求書の件です。\n支払期限は 6/30 まで&要確認。\n\nよろしくお願いします。");
+  });
+
+  it("decodes numeric and hex HTML entities in html fallback", () => {
+    const html = "<p>&#26716;&#x4E95;</p>"; // 桜井
+    const msg = {
+      id: "m6",
+      threadId: "t6",
+      payload: {
+        mimeType: "text/html",
+        headers: [
+          { name: "Subject", value: "x" },
+          { name: "From", value: "x@example.com" },
+        ],
+        body: { data: utf8B64Url(html) },
+      },
+    };
+    expect(parseMessage(msg as never).body).toBe("桜井");
+  });
+
+  it("prefers text/plain over text/html when both are present", () => {
+    const plain = "プレーン本文";
+    const msg = {
+      id: "m7",
+      threadId: "t7",
+      payload: {
+        mimeType: "multipart/alternative",
+        headers: [
+          { name: "Subject", value: "x" },
+          { name: "From", value: "x@example.com" },
+        ],
+        parts: [
+          {
+            mimeType: "text/html",
+            headers: [{ name: "Content-Type", value: "text/html; charset=UTF-8" }],
+            body: { data: utf8B64Url("<p>HTML 本文</p>") },
+          },
+          {
+            mimeType: "text/plain",
+            headers: [{ name: "Content-Type", value: "text/plain; charset=UTF-8" }],
+            body: { data: utf8B64Url(plain) },
+          },
+        ],
+      },
+    };
+    expect(parseMessage(msg as never).body).toBe(plain);
+  });
+
   it("decodes as UTF-8 even when Content-Type declares charset=ISO-2022-JP (Gmail normalizes body to UTF-8)", () => {
     // Gmail API は元メールの charset に関係なく body.data を UTF-8 バイト列で返すが、
     // Content-Type ヘッダは元メールの宣言値（例: ISO-2022-JP）が残る。


### PR DESCRIPTION
## 概要

Gmail のタスク抽出が `text/plain` パートのみを対象にしていたため、**HTML のみのメール（plain パートを持たないニュースレターや一部の自動通知）では本文が空**になり、Claude に件名だけが渡ってタスク抽出が劣化していた。HTML フォールバックを追加して解消する。

## 変更内容

- `extractBody()` を **text/plain 優先 → 無ければ text/html をタグ除去してフォールバック** する方式に変更（`cf-worker/src/clients/gmail-api.ts`）
- `extractByMime()` で MIME ツリーを mimeType 指定で再帰探索するよう共通化
- `stripHtml()` を追加。Workers 環境向けに cheerio/jsdom は使わず正規表現ベースの軽量実装：
  - `script`/`style`/`head` ブロック除去、`<br>`・ブロック要素末尾を改行に変換、残りタグ除去
  - HTML エンティティ復元（`&nbsp;` 等の名前付き＋ `&#26716;` 数値＋ `&#x4E95;` 16進）
  - 連続空白・改行の正規化

## 挙動

- `multipart/alternative`（HTML + plain 両方）→ 従来どおり plain を抽出（テストで担保）
- HTML のみ → タグ除去したテキストを抽出（**今回の修正対象**）

## テスト

`cf-worker/test/unit/clients/gmail-api.test.ts` に3ケース追加。全147テストパス。

- HTML フォールバック（タグ除去・エンティティ復元）
- 数値/16進エンティティのデコード
- plain と html 両方ある場合に plain を優先

🤖 Generated with [Claude Code](https://claude.com/claude-code)