### PR TITLE
feat: /home-arrival エンドポイント（iPhone ショートカット帰宅トリガー）

### DIFF
--- a/cf-worker/package-lock.json
+++ b/cf-worker/package-lock.json
@@ -1247,9 +1247,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1267,9 +1264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1287,9 +1281,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1307,9 +1298,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1327,9 +1315,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1347,9 +1332,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1367,9 +1349,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1387,9 +1366,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1407,9 +1383,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1433,9 +1406,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1459,9 +1429,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1485,9 +1452,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1511,9 +1475,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1537,9 +1498,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1563,9 +1521,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1589,9 +1544,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1836,9 +1788,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,9 +1802,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1816,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,9 +1830,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1844,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,9 +1858,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1938,9 +1872,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,9 +1886,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,9 +1900,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,9 +1914,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,9 +1928,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +1942,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2040,9 +1956,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4115,9 +4028,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4135,9 +4045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4155,9 +4062,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4175,9 +4079,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4195,9 +4096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4215,9 +4113,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4235,9 +4130,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4261,9 +4153,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4287,9 +4176,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4313,9 +4199,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4339,9 +4222,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4365,9 +4245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -200,6 +200,54 @@ export async function analyzeImage(env: Env, imageData: ArrayBuffer, mediaType: 
   }
 }
 
+const HOME_ARRIVAL_PROMPT = `あなたは帰宅時のタスク通知を選ぶアシスタントです。
+
+ユーザーが帰宅しました。以下のタスク一覧から、今この瞬間に通知すべきタスクを最大5件選んでください。
+
+## 選定基準
+- 期限切れ・今日・明日期限のタスクを優先する
+- 夕方〜夜の帰宅に関連する行動（子ども関連・買い物・家事・連絡）を優先する
+- 優先度 high のタスクは必ず含める（多すぎる場合は最重要のみ）
+- 仕事中にしかできないタスク（会議準備・業務連絡 等）は夜間帰宅時は除外する
+
+## 出力フォーマット（JSON のみ、説明文不要）
+
+\`\`\`json
+[
+  {"title": "通知タイトル（簡潔に20文字以内）", "priority": "high | medium | low"},
+  ...
+]
+\`\`\`
+
+タスクが0件の場合は \`[]\` を返す。`;
+
+export interface HomeArrivalNotification {
+  title: string;
+  priority: "high" | "medium" | "low";
+}
+
+export async function selectHomeArrivalNotifications(
+  env: Env,
+  tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
+  currentJstDatetime: string,
+): Promise<HomeArrivalNotification[]> {
+  const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+  const taskList = tasks
+    .map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"}, ステータス: ${t.status})`)
+    .join("\n");
+
+  const userContent = `現在時刻: ${currentJstDatetime} (JST)\n今日の日付: ${today}\n\n## タスク一覧\n${taskList}`;
+  const text = await callClaude(env, "home_arrival", HOME_ARRIVAL_PROMPT, userContent, 512);
+
+  const match = text.match(/\[[\s\S]*\]/);
+  if (!match) return [];
+  try {
+    return JSON.parse(match[0]) as HomeArrivalNotification[];
+  } catch {
+    return [];
+  }
+}
+
 export async function summarizeDay(
   env: Env,
   calendarEvents: Array<{ summary: string; start: string }>,

--- a/cf-worker/src/handlers/home-arrival.ts
+++ b/cf-worker/src/handlers/home-arrival.ts
@@ -1,0 +1,32 @@
+import type { Env } from "../types.js";
+import { getOpenTasks } from "../clients/notion.js";
+import { selectHomeArrivalNotifications, type HomeArrivalNotification } from "../clients/anthropic.js";
+import { sendMessage } from "../clients/telegram.js";
+
+function buildTelegramMessage(notifications: HomeArrivalNotification[]): string {
+  const priorityIcon: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
+  const lines = notifications.map((n) => `${priorityIcon[n.priority] ?? "•"} ${n.title}`);
+  return `🏠 *帰宅通知*\n\n${lines.join("\n")}`;
+}
+
+export async function handleHomeArrival(env: Env): Promise<HomeArrivalNotification[]> {
+  const tasks = await getOpenTasks(env);
+  if (tasks.length === 0) return [];
+
+  const jstDatetime = new Date().toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const notifications = await selectHomeArrivalNotifications(env, tasks, jstDatetime);
+  if (notifications.length > 0) {
+    await sendMessage(env, buildTelegramMessage(notifications));
+  }
+
+  return notifications;
+}

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -5,6 +5,7 @@ import { sendDailyBriefing, sendCostReport, sendEmailDigest } from "./handlers/b
 import { sendBacklogPromotionNotice, sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
 import { handleTelegramWebhook } from "./handlers/telegram.js";
 import { handleAlert } from "./handlers/alert.js";
+import { handleHomeArrival } from "./handlers/home-arrival.js";
 import { sendMessage } from "./clients/telegram.js";
 
 // 無料プランの Cron 上限（5個）に合わせて5ジョブに統合
@@ -68,6 +69,27 @@ export default {
         console.error("Alert error:", err);
       }
       return new Response("OK");
+    }
+
+    // iPhone ショートカット（帰宅Wi-Fi接続時）から呼ばれる帰宅トリガー。Bearer トークンで認証。
+    if (url.pathname === "/home-arrival" && req.method === "GET") {
+      const auth = req.headers.get("Authorization");
+      if (!env.ALERT_TOKEN || auth !== `Bearer ${env.ALERT_TOKEN}`) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      try {
+        const notifications = await handleHomeArrival(env);
+        return new Response(JSON.stringify({ notifications }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (err) {
+        console.error("home-arrival error:", err);
+        return new Response(JSON.stringify({ notifications: [] }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     }
 
     return new Response("ambient-agent", { status: 200 });

--- a/cf-worker/test/integration/home-arrival.test.ts
+++ b/cf-worker/test/integration/home-arrival.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker from "../../src/index.js";
+import { createMockEnv, sampleTasks } from "../helpers/mocks.js";
+
+vi.mock("../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+}));
+
+vi.mock("../../src/clients/anthropic.js", () => ({
+  selectHomeArrivalNotifications: vi.fn(),
+}));
+
+vi.mock("../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  getFileUrl: vi.fn(),
+  escapeMd: (t: string) => t,
+}));
+
+function homeArrivalRequest(token?: string): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return new Request("https://example.com/home-arrival", { method: "GET", headers });
+}
+
+describe("/home-arrival ingress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects request without token (401)", async () => {
+    const env = createMockEnv();
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+
+    const resp = await worker.fetch(homeArrivalRequest(), env);
+    expect(resp.status).toBe(401);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects request with wrong token (401)", async () => {
+    const env = createMockEnv();
+    const resp = await worker.fetch(homeArrivalRequest("wrong-token"), env);
+    expect(resp.status).toBe(401);
+  });
+
+  it("returns notifications JSON when tasks exist", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../src/clients/notion.js");
+    const { selectHomeArrivalNotifications } = await import("../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectHomeArrivalNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "子どもの宿題を確認", priority: "high" },
+    ]);
+
+    const resp = await worker.fetch(homeArrivalRequest(env.ALERT_TOKEN), env);
+    expect(resp.status).toBe(200);
+    const body = await resp.json<{ notifications: unknown[] }>();
+    expect(body.notifications).toHaveLength(1);
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("帰宅通知"));
+  });
+
+  it("returns empty array and skips Telegram when no tasks", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../src/clients/notion.js");
+    const { sendMessage } = await import("../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const resp = await worker.fetch(homeArrivalRequest(env.ALERT_TOKEN), env);
+    expect(resp.status).toBe(200);
+    const body = await resp.json<{ notifications: unknown[] }>();
+    expect(body.notifications).toHaveLength(0);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 with empty notifications when handler throws", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../src/clients/notion.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Notion error"));
+
+    const resp = await worker.fetch(homeArrivalRequest(env.ALERT_TOKEN), env);
+    expect(resp.status).toBe(500);
+    const body = await resp.json<{ notifications: unknown[] }>();
+    expect(body.notifications).toHaveLength(0);
+  });
+});

--- a/cf-worker/test/unit/handlers/home-arrival.test.ts
+++ b/cf-worker/test/unit/handlers/home-arrival.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleHomeArrival } from "../../../src/handlers/home-arrival.js";
+import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/anthropic.js", () => ({
+  selectHomeArrivalNotifications: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("handleHomeArrival", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array without calling Claude when no open tasks", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectHomeArrivalNotifications } = await import("../../../src/clients/anthropic.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await handleHomeArrival(env);
+    expect(result).toEqual([]);
+    expect(selectHomeArrivalNotifications).not.toHaveBeenCalled();
+  });
+
+  it("passes tasks to Claude and sends Telegram message with priority icons", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectHomeArrivalNotifications } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectHomeArrivalNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "子どもの宿題を確認", priority: "high" },
+      { title: "夕食の買い物", priority: "medium" },
+      { title: "洗濯物を取り込む", priority: "low" },
+    ]);
+
+    const result = await handleHomeArrival(env);
+
+    expect(result).toHaveLength(3);
+    expect(selectHomeArrivalNotifications).toHaveBeenCalledWith(env, sampleTasks(), expect.any(String));
+
+    const message = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(message).toContain("🏠");
+    expect(message).toContain("🔴");
+    expect(message).toContain("🟡");
+    expect(message).toContain("🟢");
+    expect(message).toContain("子どもの宿題を確認");
+  });
+
+  it("skips Telegram when Claude returns no notifications", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectHomeArrivalNotifications } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectHomeArrivalNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await handleHomeArrival(env);
+    expect(result).toEqual([]);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("passes JST datetime string to Claude", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectHomeArrivalNotifications } = await import("../../../src/clients/anthropic.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectHomeArrivalNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await handleHomeArrival(env);
+
+    const jstArg = (selectHomeArrivalNotifications as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    // JST datetime should contain year/month/day and time
+    expect(jstArg).toMatch(/\d{4}/);
+    expect(jstArg).toMatch(/\d{2}:\d{2}/);
+  });
+});


### PR DESCRIPTION
## Summary

- iPhone ショートカット（自宅 Wi-Fi 接続時）から `GET /home-arrival` を呼び出すと、Notion のオープンタスクを Claude が選別し、最大5件を Telegram に通知する
- `Authorization: Bearer <ALERT_TOKEN>` によるトークン認証でエンドポイントを保護
- `selectHomeArrivalNotifications`（`cf-worker/src/clients/anthropic.ts`）が優先度・期限・夕方帰宅の文脈を考慮してタスクを選定

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `cf-worker/src/handlers/home-arrival.ts` | ハンドラ本体（Notion 取得 → Claude 選定 → Telegram 送信） |
| `cf-worker/src/clients/anthropic.ts` | `selectHomeArrivalNotifications` 関数を追加 |
| `cf-worker/src/index.ts` | `GET /home-arrival` ルーティングを追加 |
| `cf-worker/test/integration/home-arrival.test.ts` | 統合テスト（認証・正常系・エラー系） |
| `cf-worker/test/unit/handlers/home-arrival.test.ts` | ユニットテスト（タスクなし・通知あり・Telegram スキップ・JST datetime） |

## iPhone ショートカット設定例

```
オートメーション: 特定の Wi-Fi に接続した時
アクション: URL を取得
URL: https://ambient-agent.eh6gac4.work/home-arrival
メソッド: GET
ヘッダー: Authorization: Bearer <ALERT_TOKEN>
```

## Test plan

- [x] `npm test` — 全 160 テスト（18 ファイル）パス
- [x] 認証なし → 401
- [x] 誤トークン → 401
- [x] タスクあり → 200 + Telegram 通知（優先度アイコン付き）
- [x] タスクなし → 200 + Telegram 送信なし
- [x] ハンドラ例外 → 500 + `{notifications: []}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)