### PR TITLE
fix: タスクリマインダー（13:00 JST）の定期実行ジョブを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Gmail・Google Calendar・Notion・Telegram を連携し、タスク抽出と日
 | 07:30〜21:30 毎時 | hourly_gmail | Gmail 未読を少しずつサイレント処理（通知せず KV に蓄積） + カレンダー同期 | なし（バックグラウンド処理のため） |
 | 07:50 | morning_prep | ①ブロックリスト学習 → ②カレンダー同期 → ③バックログ昇格 → ④優先度昇格 | あり |
 | 08:00 | morning_briefing | ①日次ブリーフィング → ②APIコストレポート → ③期限間近通知 → ④メール処理サマリ | あり |
-| 13:00 | task_reminder | 未着手タスク一覧を Telegram に送信 | あり |
 | 月 09:00 | stale_tasks | 14日以上未更新タスクを通知 | あり |
 
 > **休日スキップ**: 土日および日本の祝日（`holidays-jp.github.io` API 参照）は通知系ジョブを実行しない。帰宅通知（`/home-arrival`）も同様にスキップ。
@@ -279,8 +278,8 @@ npm run tunnel:dev   # API から token 取得 → cloudflared を spawn
 `wrangler dev --test-scheduled` 起動済みなので、以下で個別ジョブを発火できる:
 
 ```bash
-# 例: 13:00 task_reminder ジョブを実行
-curl "http://localhost:8787/__scheduled?cron=0+4+*+*+*"
+# 例: 08:00 morning_briefing ジョブを実行
+curl "http://localhost:8787/__scheduled?cron=0+23+*+*+*"
 ```
 
 `cron` クエリは `wrangler.toml` の cron 文字列をスペース区切り → `+` 置換した値を使う。

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -1,6 +1,6 @@
 import type { Env } from "./types.js";
 import { checkGmail, learnFromCancelled } from "./handlers/gmail.js";
-import { syncCalendar, sendDueSoonNotice, sendTaskReminder } from "./handlers/calendar.js";
+import { syncCalendar, sendDueSoonNotice } from "./handlers/calendar.js";
 import { sendDailyBriefing, sendCostReport, sendEmailDigest } from "./handlers/briefing.js";
 import { sendBacklogPromotionNotice, sendEscalationNotice, sendStaleTasksNotice } from "./handlers/escalation.js";
 import { handleTelegramWebhook } from "./handlers/telegram.js";
@@ -38,7 +38,6 @@ const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
   "30 22-23,0-12 * * *": hourlyGmail,  // 毎時30分 (JST 07:30-21:30): silent gmail batch
   "50 22 * * *": morningPrep,          // 07:50 JST: learn→calendar→escalation
   "0 23 * * *": morningBriefing,       // 08:00 JST: briefing→cost→due_soon→email_digest
-  "0 4 * * *": sendTaskReminder,       // 13:00 JST
   "0 0 * * 1": sendStaleTasksNotice,   // 月 09:00 JST
 };
 
@@ -46,7 +45,6 @@ const CRON_JOBS: Record<string, (env: Env) => Promise<void>> = {
 const SKIP_ON_HOLIDAY = new Set([
   "50 22 * * *",
   "0 23 * * *",
-  "0 4 * * *",
   "0 0 * * 1",
 ]);
 

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -8,7 +8,6 @@ crons = [
   "30 22-23,0-12 * * *",  # 毎時30分 (JST 07:30-21:30): hourly_gmail (silent batch)
   "50 22 * * *",          # 07:50 JST: morning_prep (learn→calendar→escalation)
   "0 23 * * *",           # 08:00 JST: morning_briefing (briefing→cost→due_soon→email_digest)
-  "0 4 * * *",            # 13:00 JST: task_reminder
   "0 0 * * 1",            # 月 09:00 JST: stale_tasks_notice
 ]
 


### PR DESCRIPTION
## Summary

- `wrangler.toml` の `"0 4 * * *"` cron エントリを削除
- `index.ts` の `CRON_JOBS` / `SKIP_ON_HOLIDAY` / import から `sendTaskReminder` を除外
- `README.md` のスケジュール表と使用例を更新
- `sendTaskReminder` 関数自体は `calendar.ts` に保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)