### PR TITLE
refactor: cf-worker 内の重複コードを共通化（テスト先行・挙動不変）

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,19 @@ ambient-agent/
 │   │   │   ├── calendar.ts       # カレンダー同期・期限通知
 │   │   │   ├── escalation.ts     # 優先度昇格・停滞タスク通知
 │   │   │   ├── gmail.ts          # Gmail 処理・ブロックリスト学習
-│   │   │   ├── home-arrival.ts   # 帰宅トリガー → Notion タスク選定 → Telegram 通知
-│   │   │   ├── office-leave.ts   # 退社トリガー → Notion タスク選定 → Telegram 通知
+│   │   │   ├── home-arrival.ts   # 帰宅トリガー（共通ランナーの薄いラッパ）
+│   │   │   ├── office-leave.ts   # 退社トリガー（共通ランナーの薄いラッパ）
+│   │   │   ├── notification-trigger.ts # 帰宅/退社 共通の通知フロー
 │   │   │   ├── task-formatter.ts # タスク一覧フォーマット
 │   │   │   └── telegram.ts       # Webhook コマンドルーティング
-│   │   └── storage/              # D1・KV アクセス層
-│   │       ├── d1.ts             # D1 CRUD ヘルパー
-│   │       └── kv.ts             # KV ヘルパー
-│   ├── test/                     # Vitest テスト（144件）
+│   │   ├── storage/              # D1・KV アクセス層
+│   │   │   ├── d1.ts             # D1 CRUD ヘルパー
+│   │   │   └── kv.ts             # KV ヘルパー
+│   │   └── utils/                # 共通ユーティリティ
+│   │       ├── holiday.ts        # 土日・祝日判定（JST）
+│   │       ├── jst.ts            # JST 日時ヘルパー（jstNow/jstDateStr/toDateStr 等）
+│   │       └── task.ts           # 優先度定数・最優先タスク選択
+│   ├── test/                     # Vitest テスト（196件）
 │   ├── migrations/               # D1 スキーマ
 │   ├── scripts/
 │   │   ├── push-secrets.mjs       # Worker Secrets 一括登録

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -1,5 +1,6 @@
 import type { Env, ExtractedTask, EmailAnalysis } from "../types.js";
 import { recordUsage } from "../storage/kv.js";
+import { jstDateStr } from "../utils/jst.js";
 
 const MODEL = "claude-haiku-4-5-20251001";
 const API_URL = "https://api.anthropic.com/v1/messages";
@@ -231,7 +232,7 @@ export async function selectHomeArrivalNotifications(
   tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
   currentJstDatetime: string,
 ): Promise<HomeArrivalNotification[]> {
-  const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+  const today = jstDateStr();
   const taskList = tasks
     .map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"}, ステータス: ${t.status})`)
     .join("\n");
@@ -275,7 +276,7 @@ export async function selectOfficeLeaveNotifications(
   tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
   currentJstDatetime: string,
 ): Promise<HomeArrivalNotification[]> {
-  const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+  const today = jstDateStr();
   const taskList = tasks
     .map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"}, ステータス: ${t.status})`)
     .join("\n");

--- a/cf-worker/src/clients/anthropic.ts
+++ b/cf-worker/src/clients/anthropic.ts
@@ -99,33 +99,40 @@ async function callClaude(
   return data.content[0]?.text ?? "";
 }
 
-function extractJsonList(text: string): ExtractedTask[] {
+/** LLM 応答テキストから最初の JSON 配列を取り出す。見つからない/パース失敗時は空配列。 */
+function extractJsonArray<T>(text: string): T[] {
   const match = text.match(/\[[\s\S]*\]/);
   if (!match) return [];
   try {
-    return JSON.parse(match[0]) as ExtractedTask[];
+    return JSON.parse(match[0]) as T[];
   } catch {
     return [];
   }
 }
 
+/** LLM 応答テキストから最初の JSON オブジェクトを取り出す。見つからない/パース失敗時は null。 */
+function extractJsonObject<T>(text: string): T | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[0]) as T;
+  } catch {
+    return null;
+  }
+}
+
 export async function extractTasksFromText(env: Env, label: string, subject: string, body: string): Promise<ExtractedTask[]> {
   const text = await callClaude(env, label, EXTRACT_TASKS_PROMPT, `件名: ${subject}\n\n本文:\n${body}`);
-  return extractJsonList(text);
+  return extractJsonArray<ExtractedTask>(text);
 }
 
 export async function analyzeEmail(env: Env, subject: string, body: string): Promise<EmailAnalysis> {
   const text = await callClaude(env, "analyze_email", ANALYZE_EMAIL_PROMPT, `件名: ${subject}\n\n本文:\n${body.slice(0, 3000)}`);
-  const match = text.match(/\{[\s\S]*\}/);
-  if (!match) return { summary: text.trim(), tasks: [] };
-  try {
-    const result = JSON.parse(match[0]) as EmailAnalysis;
-    result.tasks ??= [];
-    result.summary ??= "";
-    return result;
-  } catch {
-    return { summary: text.trim(), tasks: [] };
-  }
+  const result = extractJsonObject<EmailAnalysis>(text);
+  if (!result) return { summary: text.trim(), tasks: [] };
+  result.tasks ??= [];
+  result.summary ??= "";
+  return result;
 }
 
 /** Notion ページのタイトル候補。LLM が task_title を返さなければ件名にフォールバック。 */
@@ -136,7 +143,7 @@ export function pickTaskTitle(analysis: EmailAnalysis, subject: string): string 
 
 export async function extractTasksFromUrlContent(env: Env, url: string, content: string): Promise<ExtractedTask[]> {
   const text = await callClaude(env, "extract_tasks_url", EXTRACT_TASKS_PROMPT, `件名: ${url}\n\n本文:\n${content.slice(0, 3000)}`);
-  return extractJsonList(text);
+  return extractJsonArray<ExtractedTask>(text);
 }
 
 function imageToBase64(imageData: ArrayBuffer): string {
@@ -152,7 +159,7 @@ export async function extractTasksFromImage(env: Env, imageData: ArrayBuffer, me
     { type: "text", text: "この画像からアクションが必要なタスクを抽出してください。" },
   ];
   const text = await callClaude(env, "extract_tasks_image", EXTRACT_TASKS_PROMPT, userContent);
-  return extractJsonList(text);
+  return extractJsonArray<ExtractedTask>(text);
 }
 
 const ANALYZE_IMAGE_PROMPT = `あなたは画像からタスクを分析するアシスタントです。
@@ -189,16 +196,11 @@ export async function analyzeImage(env: Env, imageData: ArrayBuffer, mediaType: 
     { type: "text", text: "この画像を分析してください。" },
   ];
   const text = await callClaude(env, "analyze_image", ANALYZE_IMAGE_PROMPT, userContent);
-  const match = text.match(/\{[\s\S]*\}/);
-  if (!match) return { summary: text.trim(), tasks: [] };
-  try {
-    const result = JSON.parse(match[0]) as EmailAnalysis;
-    result.tasks ??= [];
-    result.summary ??= "";
-    return result;
-  } catch {
-    return { summary: text.trim(), tasks: [] };
-  }
+  const result = extractJsonObject<EmailAnalysis>(text);
+  if (!result) return { summary: text.trim(), tasks: [] };
+  result.tasks ??= [];
+  result.summary ??= "";
+  return result;
 }
 
 const HOME_ARRIVAL_PROMPT = `あなたは帰宅時のタスク通知を選ぶアシスタントです。
@@ -227,8 +229,11 @@ export interface HomeArrivalNotification {
   priority: "high" | "medium" | "low";
 }
 
-export async function selectHomeArrivalNotifications(
+/** 帰宅/退社など「現在地を離れた」タイミングのタスク通知を LLM に選ばせる共通処理。 */
+async function selectNotifications(
   env: Env,
+  job: string,
+  prompt: string,
   tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
   currentJstDatetime: string,
 ): Promise<HomeArrivalNotification[]> {
@@ -238,15 +243,16 @@ export async function selectHomeArrivalNotifications(
     .join("\n");
 
   const userContent = `現在時刻: ${currentJstDatetime} (JST)\n今日の日付: ${today}\n\n## タスク一覧\n${taskList}`;
-  const text = await callClaude(env, "home_arrival", HOME_ARRIVAL_PROMPT, userContent, 512);
+  const text = await callClaude(env, job, prompt, userContent, 512);
+  return extractJsonArray<HomeArrivalNotification>(text);
+}
 
-  const match = text.match(/\[[\s\S]*\]/);
-  if (!match) return [];
-  try {
-    return JSON.parse(match[0]) as HomeArrivalNotification[];
-  } catch {
-    return [];
-  }
+export async function selectHomeArrivalNotifications(
+  env: Env,
+  tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
+  currentJstDatetime: string,
+): Promise<HomeArrivalNotification[]> {
+  return selectNotifications(env, "home_arrival", HOME_ARRIVAL_PROMPT, tasks, currentJstDatetime);
 }
 
 const OFFICE_LEAVE_PROMPT = `あなたは退社時のタスク通知を選ぶアシスタントです。
@@ -276,21 +282,7 @@ export async function selectOfficeLeaveNotifications(
   tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
   currentJstDatetime: string,
 ): Promise<HomeArrivalNotification[]> {
-  const today = jstDateStr();
-  const taskList = tasks
-    .map((t) => `- [${t.priority}] ${t.title} (期限: ${t.due ?? "未定"}, ステータス: ${t.status})`)
-    .join("\n");
-
-  const userContent = `現在時刻: ${currentJstDatetime} (JST)\n今日の日付: ${today}\n\n## タスク一覧\n${taskList}`;
-  const text = await callClaude(env, "office_leave", OFFICE_LEAVE_PROMPT, userContent, 512);
-
-  const match = text.match(/\[[\s\S]*\]/);
-  if (!match) return [];
-  try {
-    return JSON.parse(match[0]) as HomeArrivalNotification[];
-  } catch {
-    return [];
-  }
+  return selectNotifications(env, "office_leave", OFFICE_LEAVE_PROMPT, tasks, currentJstDatetime);
 }
 
 export async function summarizeDay(

--- a/cf-worker/src/clients/gcal-api.ts
+++ b/cf-worker/src/clients/gcal-api.ts
@@ -1,5 +1,6 @@
 import type { Env, CalendarEvent } from "../types.js";
 import { getAccessToken } from "./google-auth.js";
+import { jstNow } from "../utils/jst.js";
 
 const BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
 
@@ -10,7 +11,7 @@ function authHeader(token: string): Record<string, string> {
 export async function getTodaysEvents(env: Env): Promise<CalendarEvent[]> {
   const token = await getAccessToken(env);
 
-  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const now = jstNow();
   const start = new Date(now);
   start.setHours(0, 0, 0, 0);
   const end = new Date(now);

--- a/cf-worker/src/clients/gcal-api.ts
+++ b/cf-worker/src/clients/gcal-api.ts
@@ -1,12 +1,8 @@
 import type { Env, CalendarEvent } from "../types.js";
-import { getAccessToken } from "./google-auth.js";
+import { getAccessToken, authHeader } from "./google-auth.js";
 import { jstNow } from "../utils/jst.js";
 
 const BASE = "https://www.googleapis.com/calendar/v3/calendars/primary";
-
-function authHeader(token: string): Record<string, string> {
-  return { Authorization: `Bearer ${token}` };
-}
 
 export async function getTodaysEvents(env: Env): Promise<CalendarEvent[]> {
   const token = await getAccessToken(env);

--- a/cf-worker/src/clients/gmail-api.ts
+++ b/cf-worker/src/clients/gmail-api.ts
@@ -1,5 +1,5 @@
 import type { Env } from "../types.js";
-import { getAccessToken } from "./google-auth.js";
+import { getAccessToken, authHeader } from "./google-auth.js";
 
 const BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 const GMAIL_QUERY = "is:unread in:inbox -category:promotions";
@@ -16,10 +16,6 @@ interface GmailPayload {
   mimeType: string;
   body?: { data?: string };
   parts?: GmailPayload[];
-}
-
-function authHeader(token: string): Record<string, string> {
-  return { Authorization: `Bearer ${token}` };
 }
 
 function parseHeaders(payload: GmailPayload): Record<string, string> {

--- a/cf-worker/src/clients/google-auth.ts
+++ b/cf-worker/src/clients/google-auth.ts
@@ -7,6 +7,11 @@ interface TokenCache {
   expiresAt: number;
 }
 
+/** Google API 用の Bearer 認可ヘッダを組み立てる。 */
+export function authHeader(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
 export async function getAccessToken(env: Env): Promise<string> {
   const cached = await env.AGENT_KV.get<TokenCache>(TOKEN_KV_KEY, "json");
   if (cached && cached.expiresAt > Date.now() + 60_000) {

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -1,5 +1,6 @@
 import type { Env, Task, TaskInput, ExtractedTask } from "../types.js";
 import { toDateStr } from "../utils/jst.js";
+import { PRIORITY_ORDER } from "../utils/task.js";
 
 const NOTION_API = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
@@ -80,6 +81,32 @@ function headers(token: string): Record<string, string> {
 
 function getSubitemParentProp(env: Env): string {
   return env.NOTION_SUBITEM_PARENT_PROP ?? "親アイテム";
+}
+
+/**
+ * ページの properties を PATCH する共通リクエスト。Response をそのまま返すので、
+ * エラー時に throw するか黙殺するか（fire-and-forget）は呼び出し側の判断に委ねる。
+ */
+function patchNotionPage(env: Env, pageId: string, properties: Record<string, unknown>): Promise<Response> {
+  return fetch(`${NOTION_API}/pages/${pageId}`, {
+    method: "PATCH",
+    headers: headers(env.NOTION_TOKEN),
+    body: JSON.stringify({ properties }),
+  });
+}
+
+/**
+ * ページを取得し properties を返す。取得失敗(!ok)・アーカイブ済みは null。
+ * （!ok を throw する経路や archived を見ない経路では使わないこと）
+ */
+async function fetchTaskPage(env: Env, pageId: string): Promise<Record<string, unknown> | null> {
+  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
+    headers: headers(env.NOTION_TOKEN),
+  });
+  if (!resp.ok) return null;
+  const page = await resp.json<{ archived?: boolean; properties?: Record<string, unknown> }>();
+  if (page.archived) return null;
+  return (page.properties ?? {}) as Record<string, unknown>;
 }
 
 async function getDataSourceId(env: Env): Promise<string | null> {
@@ -326,11 +353,7 @@ export async function escalatePriorityTasks(env: Env): Promise<Task[]> {
   const escalated: Task[] = [];
   for (const page of result.results as Record<string, unknown>[]) {
     const task = parseTaskPage(page);
-    await fetch(`${NOTION_API}/pages/${task.pageId}`, {
-      method: "PATCH",
-      headers: headers(env.NOTION_TOKEN),
-      body: JSON.stringify({ properties: { Priority: { select: { name: "high" } } } }),
-    });
+    await patchNotionPage(env, task.pageId, { Priority: { select: { name: "high" } } });
     escalated.push(task);
   }
   return escalated;
@@ -354,42 +377,26 @@ export async function promoteBacklogTasks(env: Env): Promise<Task[]> {
   const promoted: Task[] = [];
   for (const page of result.results as Record<string, unknown>[]) {
     const task = parseTaskPage(page);
-    await fetch(`${NOTION_API}/pages/${task.pageId}`, {
-      method: "PATCH",
-      headers: headers(env.NOTION_TOKEN),
-      body: JSON.stringify({ properties: { Status: { status: { name: STATUS_PENDING } } } }),
-    });
+    await patchNotionPage(env, task.pageId, { Status: { status: { name: STATUS_PENDING } } });
     promoted.push(task);
   }
   return promoted;
 }
 
 export async function completeTask(env: Env, pageId: string): Promise<void> {
-  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
-    method: "PATCH",
-    headers: headers(env.NOTION_TOKEN),
-    body: JSON.stringify({ properties: { Status: { status: { name: STATUS_DONE } } } }),
-  });
+  const resp = await patchNotionPage(env, pageId, { Status: { status: { name: STATUS_DONE } } });
   if (!resp.ok) throw new Error(`completeTask failed: ${resp.status}`);
 }
 
 export async function cancelTask(env: Env, pageId: string): Promise<void> {
-  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
-    method: "PATCH",
-    headers: headers(env.NOTION_TOKEN),
-    body: JSON.stringify({ properties: { Status: { status: { name: STATUS_CANCELLED } } } }),
-  });
+  const resp = await patchNotionPage(env, pageId, { Status: { status: { name: STATUS_CANCELLED } } });
   if (!resp.ok) throw new Error(`cancelTask failed: ${resp.status}`);
 }
 
 export async function getTaskStatus(env: Env, pageId: string): Promise<string | null> {
-  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
-    headers: headers(env.NOTION_TOKEN),
-  });
-  if (!resp.ok) return null;
-  const page = await resp.json<{ archived?: boolean; properties?: Record<string, unknown> }>();
-  if (page.archived) return null;
-  const statusObj = (page.properties?.["Status"] as Record<string, unknown> | undefined)?.status as { name: string } | undefined;
+  const props = await fetchTaskPage(env, pageId);
+  if (!props) return null;
+  const statusObj = (props["Status"] as Record<string, unknown> | undefined)?.status as { name: string } | undefined;
   return statusObj?.name ?? null;
 }
 
@@ -397,13 +404,8 @@ export async function getTaskTitleAndDue(
   env: Env,
   pageId: string,
 ): Promise<{ title: string; due: string | null } | null> {
-  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
-    headers: headers(env.NOTION_TOKEN),
-  });
-  if (!resp.ok) return null;
-  const page = await resp.json<{ archived?: boolean; properties?: Record<string, unknown> }>();
-  if (page.archived) return null;
-  const props = (page.properties ?? {}) as Record<string, unknown>;
+  const props = await fetchTaskPage(env, pageId);
+  if (!props) return null;
   const titleArr = ((props["タイトル"] as Record<string, unknown> | undefined)?.title as Array<{ text: { content: string } }> | undefined) ?? [];
   const title = titleArr[0]?.text.content ?? "";
   const dueObj = (props["Due"] as Record<string, unknown> | undefined)?.date as { start: string } | undefined;
@@ -411,11 +413,7 @@ export async function getTaskTitleAndDue(
 }
 
 export async function updateTaskDue(env: Env, pageId: string, due: string): Promise<void> {
-  const resp = await fetch(`${NOTION_API}/pages/${pageId}`, {
-    method: "PATCH",
-    headers: headers(env.NOTION_TOKEN),
-    body: JSON.stringify({ properties: { Due: { date: { start: due } } } }),
-  });
+  const resp = await patchNotionPage(env, pageId, { Due: { date: { start: due } } });
   if (!resp.ok) throw new Error(`updateTaskDue failed: ${resp.status}`);
 }
 
@@ -427,8 +425,6 @@ export async function updateTaskFromReply(
   due: string | null,
   bodyText?: string,
 ): Promise<void> {
-  const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
-
   const pageResp = await fetch(`${NOTION_API}/pages/${pageId}`, {
     headers: headers(env.NOTION_TOKEN),
   });
@@ -444,7 +440,7 @@ export async function updateTaskFromReply(
 
   const updates: Record<string, unknown> = {};
 
-  if ((priorityOrder[priority] ?? 1) < (priorityOrder[currentPriority] ?? 1)) {
+  if ((PRIORITY_ORDER[priority] ?? 1) < (PRIORITY_ORDER[currentPriority] ?? 1)) {
     updates["Priority"] = { select: { name: priority } };
   }
 
@@ -456,11 +452,7 @@ export async function updateTaskFromReply(
   }
 
   if (Object.keys(updates).length) {
-    await fetch(`${NOTION_API}/pages/${pageId}`, {
-      method: "PATCH",
-      headers: headers(env.NOTION_TOKEN),
-      body: JSON.stringify({ properties: updates }),
-    });
+    await patchNotionPage(env, pageId, updates);
   }
 
   const bodyBlocks = buildEmailBodyBlocks(bodyText ?? "", "📧 返信メール");

--- a/cf-worker/src/clients/notion.ts
+++ b/cf-worker/src/clients/notion.ts
@@ -1,4 +1,5 @@
 import type { Env, Task, TaskInput, ExtractedTask } from "../types.js";
+import { toDateStr } from "../utils/jst.js";
 
 const NOTION_API = "https://api.notion.com/v1";
 const NOTION_VERSION = "2022-06-28";
@@ -303,10 +304,10 @@ export async function getOpenTasks(env: Env): Promise<Task[]> {
 export async function escalatePriorityTasks(env: Env): Promise<Task[]> {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  const todayStr = today.toISOString().slice(0, 10);
+  const todayStr = toDateStr(today);
   const deadline = new Date(today);
   deadline.setDate(deadline.getDate() + 3);
-  const deadlineStr = deadline.toISOString().slice(0, 10);
+  const deadlineStr = toDateStr(deadline);
 
   const statusFilters = [STATUS_PENDING, ...STATUS_IN_PROGRESS_GROUP].map((s) => ({
     property: "Status",
@@ -341,7 +342,7 @@ export async function promoteBacklogTasks(env: Env): Promise<Task[]> {
   const today = new Date();
   const deadline = new Date(today);
   deadline.setDate(deadline.getDate() + 3);
-  const deadlineStr = deadline.toISOString().slice(0, 10);
+  const deadlineStr = toDateStr(deadline);
 
   const result = await queryDB(env, {
     and: [

--- a/cf-worker/src/handlers/briefing.ts
+++ b/cf-worker/src/handlers/briefing.ts
@@ -4,6 +4,8 @@ import { getOpenTasks } from "../clients/notion.js";
 import { summarizeDay } from "../clients/anthropic.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { getDailyUsage, takeEmailDigest } from "../storage/kv.js";
+import { PRIORITY_ICON } from "../utils/task.js";
+import { jstNow, toDateStr } from "../utils/jst.js";
 
 const PRICE_INPUT_PER_M = 0.8;
 const PRICE_OUTPUT_PER_M = 4.0;
@@ -47,8 +49,7 @@ function formatEventsSection(events: CalendarEvent[]): string {
 
 function formatOverdueSection(overdue: Task[]): string {
   if (!overdue.length) return "";
-  const icon = { high: "🔴", medium: "🟡", low: "🟢" } as const;
-  const lines = overdue.map((t) => `• ${icon[t.priority]} ${escapeMd(t.title)} (${formatDueShort(t.due)})`);
+  const lines = overdue.map((t) => `• ${PRIORITY_ICON[t.priority]} ${escapeMd(t.title)} (${formatDueShort(t.due)})`);
   return `*⚠️ 期限切れ (${overdue.length}件)*\n${lines.join("\n")}`;
 }
 
@@ -73,9 +74,7 @@ function formatTasksSection(tasks: Task[]): string {
 export async function sendDailyBriefing(env: Env): Promise<void> {
   const [events, tasks] = await Promise.all([getTodaysEvents(env), getOpenTasks(env)]);
 
-  const todayStr = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }))
-    .toISOString()
-    .slice(0, 10);
+  const todayStr = toDateStr(jstNow());
   const overdue = tasks.filter((t) => t.due && t.due.slice(0, 10) < todayStr);
   const openTasks = tasks.filter((t) => !overdue.includes(t));
 
@@ -94,7 +93,7 @@ export async function sendDailyBriefing(env: Env): Promise<void> {
 }
 
 export async function sendCostReport(env: Env): Promise<void> {
-  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const now = jstNow();
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
   const yesterdayStr = yesterday.toISOString().slice(0, 10);

--- a/cf-worker/src/handlers/calendar.ts
+++ b/cf-worker/src/handlers/calendar.ts
@@ -4,6 +4,7 @@ import { getOpenTasks } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { formatTaskList, fmtDue } from "./task-formatter.js";
 import { getCalendarSync, setCalendarSync, deleteCalendarSync, getAllCalendarSync } from "../storage/d1.js";
+import { jstNow } from "../utils/jst.js";
 
 export async function syncCalendar(env: Env): Promise<void> {
   const tasks = await getOpenTasks(env);
@@ -102,7 +103,7 @@ export async function deleteCalendarEventForTask(env: Env, pageId: string): Prom
 
 export async function sendDueSoonNotice(env: Env): Promise<void> {
   const tasks = await getOpenTasks(env);
-  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const now = jstNow();
   const today = now.toISOString().slice(0, 10);
   const tomorrow = new Date(now);
   tomorrow.setDate(tomorrow.getDate() + 1);

--- a/cf-worker/src/handlers/escalation.ts
+++ b/cf-worker/src/handlers/escalation.ts
@@ -2,6 +2,7 @@ import type { Env } from "../types.js";
 import { getOpenTasks, escalatePriorityTasks, promoteBacklogTasks } from "../clients/notion.js";
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { fmtDue } from "./task-formatter.js";
+import { jstNow } from "../utils/jst.js";
 
 const STALE_DAYS = 14;
 
@@ -29,7 +30,7 @@ export async function sendBacklogPromotionNotice(env: Env): Promise<void> {
 
 export async function sendStaleTasksNotice(env: Env): Promise<void> {
   const tasks = await getOpenTasks(env);
-  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const now = jstNow();
   const cutoff = new Date(now);
   cutoff.setDate(cutoff.getDate() - STALE_DAYS);
   const cutoffStr = cutoff.toISOString().slice(0, 10);

--- a/cf-worker/src/handlers/gmail.ts
+++ b/cf-worker/src/handlers/gmail.ts
@@ -5,6 +5,7 @@ import { addTask, updateTaskFromReply, getTaskStatus, getTaskTitleAndDue } from 
 import { sendMessage, escapeMd } from "../clients/telegram.js";
 import { taskLink } from "./telegram.js";
 import { syncTaskCalendarEventSafe } from "./calendar.js";
+import { bestPriorityTask } from "../utils/task.js";
 import {
   getThreadMapEntry,
   setThreadMapEntry,
@@ -65,10 +66,7 @@ export async function checkGmail(env: Env, options: CheckGmailOptions = {}): Pro
       const taskTitle = pickTaskTitle(analysis, subject);
 
       if (tasks.length) {
-        const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
-        const best = tasks.reduce((a, b) =>
-          (priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b,
-        );
+        const best = bestPriorityTask(tasks);
         const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
         const subtaskTitles = tasks.map((t) => t.title);
 

--- a/cf-worker/src/handlers/home-arrival.ts
+++ b/cf-worker/src/handlers/home-arrival.ts
@@ -1,35 +1,7 @@
 import type { Env } from "../types.js";
-import { getOpenTasks } from "../clients/notion.js";
 import { selectHomeArrivalNotifications, type HomeArrivalNotification } from "../clients/anthropic.js";
-import { sendMessage } from "../clients/telegram.js";
-import { isHoliday } from "../utils/holiday.js";
-
-function buildTelegramMessage(notifications: HomeArrivalNotification[]): string {
-  const priorityIcon: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
-  const lines = notifications.map((n) => `${priorityIcon[n.priority] ?? "•"} ${n.title}`);
-  return `🏠 *帰宅通知*\n\n${lines.join("\n")}`;
-}
+import { runNotificationTrigger } from "./notification-trigger.js";
 
 export async function handleHomeArrival(env: Env): Promise<HomeArrivalNotification[]> {
-  if (await isHoliday()) return [];
-
-  const tasks = await getOpenTasks(env);
-  if (tasks.length === 0) return [];
-
-  const jstDatetime = new Date().toLocaleString("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-
-  const notifications = await selectHomeArrivalNotifications(env, tasks, jstDatetime);
-  if (notifications.length > 0) {
-    await sendMessage(env, buildTelegramMessage(notifications));
-  }
-
-  return notifications;
+  return runNotificationTrigger(env, selectHomeArrivalNotifications, "🏠 *帰宅通知*");
 }

--- a/cf-worker/src/handlers/notification-trigger.ts
+++ b/cf-worker/src/handlers/notification-trigger.ts
@@ -1,0 +1,41 @@
+import type { Env } from "../types.js";
+import { getOpenTasks } from "../clients/notion.js";
+import type { HomeArrivalNotification } from "../clients/anthropic.js";
+import { sendMessage } from "../clients/telegram.js";
+import { isHoliday } from "../utils/holiday.js";
+import { jstDateTimeStr } from "../utils/jst.js";
+import { PRIORITY_ICON } from "../utils/task.js";
+
+type SelectFn = (
+  env: Env,
+  tasks: Array<{ title: string; priority: string; due: string | null; status: string }>,
+  currentJstDatetime: string,
+) => Promise<HomeArrivalNotification[]>;
+
+function buildTelegramMessage(header: string, notifications: HomeArrivalNotification[]): string {
+  const lines = notifications.map((n) => `${PRIORITY_ICON[n.priority] ?? "•"} ${n.title}`);
+  return `${header}\n\n${lines.join("\n")}`;
+}
+
+/**
+ * 帰宅・退社など「ある場所を離れた」タイミング共通の通知フロー。
+ * 祝日はスキップ、未完了タスクが無ければ何もしない。LLM が通知を選んだら
+ * Telegram に送信する。header は通知の見出し（例: "🏠 *帰宅通知*"）。
+ */
+export async function runNotificationTrigger(
+  env: Env,
+  select: SelectFn,
+  header: string,
+): Promise<HomeArrivalNotification[]> {
+  if (await isHoliday()) return [];
+
+  const tasks = await getOpenTasks(env);
+  if (tasks.length === 0) return [];
+
+  const notifications = await select(env, tasks, jstDateTimeStr());
+  if (notifications.length > 0) {
+    await sendMessage(env, buildTelegramMessage(header, notifications));
+  }
+
+  return notifications;
+}

--- a/cf-worker/src/handlers/office-leave.ts
+++ b/cf-worker/src/handlers/office-leave.ts
@@ -1,35 +1,7 @@
 import type { Env } from "../types.js";
-import { getOpenTasks } from "../clients/notion.js";
 import { selectOfficeLeaveNotifications, type HomeArrivalNotification } from "../clients/anthropic.js";
-import { sendMessage } from "../clients/telegram.js";
-import { isHoliday } from "../utils/holiday.js";
-
-function buildTelegramMessage(notifications: HomeArrivalNotification[]): string {
-  const priorityIcon: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
-  const lines = notifications.map((n) => `${priorityIcon[n.priority] ?? "•"} ${n.title}`);
-  return `🏢 *退社通知*\n\n${lines.join("\n")}`;
-}
+import { runNotificationTrigger } from "./notification-trigger.js";
 
 export async function handleOfficeLeave(env: Env): Promise<HomeArrivalNotification[]> {
-  if (await isHoliday()) return [];
-
-  const tasks = await getOpenTasks(env);
-  if (tasks.length === 0) return [];
-
-  const jstDatetime = new Date().toLocaleString("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-
-  const notifications = await selectOfficeLeaveNotifications(env, tasks, jstDatetime);
-  if (notifications.length > 0) {
-    await sendMessage(env, buildTelegramMessage(notifications));
-  }
-
-  return notifications;
+  return runNotificationTrigger(env, selectOfficeLeaveNotifications, "🏢 *退社通知*");
 }

--- a/cf-worker/src/handlers/task-formatter.ts
+++ b/cf-worker/src/handlers/task-formatter.ts
@@ -1,10 +1,10 @@
 import type { Task } from "../types.js";
 import { escapeMd } from "../clients/telegram.js";
+import { PRIORITY_ORDER, PRIORITY_ICON } from "../utils/task.js";
+import { jstNow } from "../utils/jst.js";
 
 const TASK_APP_URL = "https://todo.eh6gac4.work";
 
-const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
-const PRIORITY_LABELS: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
 const STATUS_ORDER: Record<string, number> = { 未着手: 0, 進行中: 1, 確認中: 2, 一時中断: 3 };
 const STATUS_LABELS: Record<string, string> = {
   未着手: "📋 未着手",
@@ -20,7 +20,7 @@ export function fmtDue(d: string | null): string {
   const due = new Date(d.slice(0, 10) + "T00:00:00+09:00");
   if (isNaN(due.getTime())) return d;
 
-  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const now = jstNow();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const delta = Math.round((due.getTime() - today.getTime()) / 86400000);
 
@@ -67,7 +67,7 @@ export function formatTaskList(tasks: Task[], numbered = false): string {
       lines.push(`\n*${STATUS_LABELS[t.status] ?? t.status}*`);
     }
     const due = t.due ? `（${fmtDue(t.due)}）` : "";
-    const icon = PRIORITY_LABELS[t.priority] ?? "";
+    const icon = PRIORITY_ICON[t.priority] ?? "";
     const prefix = numbered ? `${i + 1}. ` : "• ";
     // escapeMd は \ * _ ` [ を処理する。リンクテキスト内は ] も閉じ括弧扱いになるため追加でエスケープ。
     const safeTitle = escapeMd(t.title);

--- a/cf-worker/src/handlers/telegram.ts
+++ b/cf-worker/src/handlers/telegram.ts
@@ -7,6 +7,8 @@ import { getTaskCache, setTaskCache, getNoTaskSenders, addNoTaskSender, removeNo
 import { deleteCalendarEventForTask, syncTaskCalendarEventSafe } from "./calendar.js";
 import { formatTaskList, sortTasks } from "./task-formatter.js";
 import { sendDailyBriefing } from "./briefing.js";
+import { bestPriorityTask } from "../utils/task.js";
+import { jstNow } from "../utils/jst.js";
 
 const URL_PATTERN = /https?:\/\/\S+/;
 const OPERATING_START_HOUR = 8;
@@ -21,7 +23,7 @@ export function taskLink(pageId: string): string {
 }
 
 function getJstHour(): number {
-  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" })).getHours();
+  return jstNow().getHours();
 }
 
 function extractTextFromHtml(html: string): string {
@@ -227,9 +229,8 @@ async function handlePhoto(env: Env, message: Record<string, unknown>): Promise<
 
   const subtaskTitles = tasks.map((t) => t.title);
   const dues = tasks.map((t) => t.due).filter((d): d is string => Boolean(d)).sort();
-  const priorityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
   const best: Pick<ExtractedTask, "priority" | "icon"> = tasks.length
-    ? tasks.reduce((a, b) => ((priorityOrder[a.priority] ?? 1) <= (priorityOrder[b.priority] ?? 1) ? a : b))
+    ? bestPriorityTask(tasks)
     : { priority: "medium", icon: FALLBACK_ICON.photo };
   const title = (summary || tasks[0]?.title || "📷 画像メモ").slice(0, 200);
 

--- a/cf-worker/src/utils/jst.ts
+++ b/cf-worker/src/utils/jst.ts
@@ -1,0 +1,34 @@
+// JST(Asia/Tokyo)に関する日時ヘルパー。
+// 注意: utils/holiday.ts は独自実装の private ヘルパー（UTC オフセット加算方式）を
+// 持つが、本ファイルは `toLocaleString` ベースの式を集約したもので実装が異なる。
+// 値の意味が違うため両者は統合しない。
+
+const TZ = "Asia/Tokyo";
+
+/** 現在時刻を JST の壁時計として読める Date（getHours/setHours 等が JST 値になる）。 */
+export function jstNow(): Date {
+  return new Date(new Date().toLocaleString("en-US", { timeZone: TZ }));
+}
+
+/** 今日の日付を JST の YYYY-MM-DD で返す（sv-SE ロケール）。 */
+export function jstDateStr(): string {
+  return new Date().toLocaleDateString("sv-SE", { timeZone: TZ });
+}
+
+/** 現在時刻を JST の "YYYY/MM/DD HH:MM" 形式（ja-JP, 24 時間表記）で返す。 */
+export function jstDateTimeStr(): string {
+  return new Date().toLocaleString("ja-JP", {
+    timeZone: TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+/** Date を UTC 基準の YYYY-MM-DD 文字列に変換する。 */
+export function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/cf-worker/src/utils/task.ts
+++ b/cf-worker/src/utils/task.ts
@@ -1,0 +1,17 @@
+// タスクの優先度に関する共通定数・ヘルパー。
+
+/** 優先度の並び順（小さいほど高優先）。不明な優先度は medium 相当(1)として扱う。 */
+export const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+/** 優先度に対応する絵文字アイコン。 */
+export const PRIORITY_ICON: Record<string, string> = { high: "🔴", medium: "🟡", low: "🟢" };
+
+/**
+ * 最も優先度の高いタスクを返す（high > medium > low、不明は medium 相当）。
+ * tasks は非空であること（空配列を渡すと reduce が例外を投げる）。
+ */
+export function bestPriorityTask<T extends { priority: string }>(tasks: T[]): T {
+  return tasks.reduce((a, b) =>
+    (PRIORITY_ORDER[a.priority] ?? 1) <= (PRIORITY_ORDER[b.priority] ?? 1) ? a : b,
+  );
+}

--- a/cf-worker/test/unit/clients/anthropic.test.ts
+++ b/cf-worker/test/unit/clients/anthropic.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { analyzeEmail, extractTasksFromText, extractTasksFromUrlContent, pickTaskTitle } from "../../../src/clients/anthropic.js";
+import {
+  analyzeEmail,
+  extractTasksFromText,
+  extractTasksFromUrlContent,
+  pickTaskTitle,
+  selectHomeArrivalNotifications,
+  selectOfficeLeaveNotifications,
+} from "../../../src/clients/anthropic.js";
 import { createMockEnv } from "../../helpers/mocks.js";
 import claudeFixtures from "../../fixtures/claude-responses.json" assert { type: "json" };
 
@@ -103,5 +110,64 @@ describe("extractTasksFromUrlContent", () => {
     await extractTasksFromUrlContent(env, "https://example.com/task", "コンテンツ");
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.messages[0].content).toContain("https://example.com/task");
+  });
+});
+
+describe("selectHomeArrivalNotifications / selectOfficeLeaveNotifications", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const tasks = [
+    { title: "牛乳を買う", priority: "medium", due: "2026-06-14", status: "未着手" },
+    { title: "請求書を提出", priority: "high", due: null, status: "進行中" },
+  ];
+
+  function stubArrayResponse(arr: unknown) {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        content: [{ type: "text", text: JSON.stringify(arr) }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("home arrival parses notifications and uses the home prompt", async () => {
+    const env = createMockEnv();
+    const fetchMock = stubArrayResponse([{ title: "牛乳を買う", priority: "medium" }]);
+
+    const result = await selectHomeArrivalNotifications(env, tasks, "2026/06/14 19:00");
+    expect(result).toEqual([{ title: "牛乳を買う", priority: "medium" }]);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.system).toContain("帰宅");
+    expect(body.messages[0].content).toContain("2026/06/14 19:00");
+  });
+
+  it("office leave parses notifications and uses the office prompt", async () => {
+    const env = createMockEnv();
+    const fetchMock = stubArrayResponse([{ title: "請求書を提出", priority: "high" }]);
+
+    const result = await selectOfficeLeaveNotifications(env, tasks, "2026/06/14 18:00");
+    expect(result).toEqual([{ title: "請求書を提出", priority: "high" }]);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.system).toContain("退社");
+  });
+
+  it("returns empty array when response has no JSON array", async () => {
+    const env = createMockEnv();
+    stubArrayResponse(null); // serializes to "null", no [...] match
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        content: [{ type: "text", text: "通知すべきタスクはありません" }],
+        usage: { input_tokens: 5, output_tokens: 2 },
+      }), { status: 200 }),
+    ));
+
+    const result = await selectHomeArrivalNotifications(env, tasks, "2026/06/14 19:00");
+    expect(result).toEqual([]);
   });
 });

--- a/cf-worker/test/unit/clients/gcal-api.test.ts
+++ b/cf-worker/test/unit/clients/gcal-api.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getTodaysEvents,
+  insertEvent,
+  updateEventDateTime,
+  deleteEvent,
+} from "../../../src/clients/gcal-api.js";
+import { createMockEnv } from "../../helpers/mocks.js";
+
+vi.mock("../../../src/clients/google-auth.js", () => ({
+  getAccessToken: vi.fn().mockResolvedValue("test-access-token"),
+}));
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function stubFetch(responder: (call: FetchCall) => Response): {
+  calls: FetchCall[];
+  fn: ReturnType<typeof vi.fn>;
+} {
+  const calls: FetchCall[] = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    const call = { url, init };
+    calls.push(call);
+    return responder(call);
+  });
+  vi.stubGlobal("fetch", fn);
+  return { calls, fn };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("gcal-api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("getTodaysEvents", () => {
+    it("requests JST day window and maps items", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() =>
+        json({
+          items: [
+            { summary: "会議", start: { dateTime: "2026-06-14T10:00:00+09:00" } },
+            { summary: "終日イベント", start: { date: "2026-06-14" } },
+            { start: { dateTime: "2026-06-14T15:00:00+09:00" } },
+          ],
+        }),
+      );
+
+      const events = await getTodaysEvents(env);
+
+      const url = calls[0].url;
+      expect(url).toContain("singleEvents=true");
+      expect(url).toContain("orderBy=startTime");
+      // timeMin / timeMax carry the +09:00 JST offset (URL-encoded as %2B09%3A00)
+      expect(url).toContain("timeMin=");
+      expect(url).toContain("timeMax=");
+      expect(url).toContain("%2B09%3A00");
+      expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer test-access-token" });
+
+      expect(events).toEqual([
+        { summary: "会議", start: "2026-06-14T10:00:00+09:00" },
+        { summary: "終日イベント", start: "2026-06-14" },
+        { summary: "", start: "2026-06-14T15:00:00+09:00" },
+      ]);
+    });
+
+    it("returns empty array when items missing", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}));
+      expect(await getTodaysEvents(env)).toEqual([]);
+    });
+
+    it("throws on non-ok response", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}, 500));
+      await expect(getTodaysEvents(env)).rejects.toThrow("500");
+    });
+  });
+
+  describe("insertEvent", () => {
+    it("creates a timed event with 1h duration and Asia/Tokyo tz", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() => json({ id: "evt-1" }));
+
+      const id = await insertEvent(env, "打合せ", "2026-06-14T09:00");
+      expect(id).toBe("evt-1");
+
+      const body = JSON.parse(calls[0].init!.body as string);
+      expect(body.summary).toBe("打合せ");
+      expect(body.start.timeZone).toBe("Asia/Tokyo");
+      expect(body.end.timeZone).toBe("Asia/Tokyo");
+      expect(body.start.dateTime).toBeDefined();
+      expect(body.end.dateTime).toBeDefined();
+      const startMs = new Date(body.start.dateTime).getTime();
+      const endMs = new Date(body.end.dateTime).getTime();
+      expect(endMs - startMs).toBe(60 * 60 * 1000);
+      expect(calls[0].init?.method).toBe("POST");
+    });
+
+    it("creates an all-day event when due has no time", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() => json({ id: "evt-2" }));
+
+      const id = await insertEvent(env, "締切", "2026-06-14");
+      expect(id).toBe("evt-2");
+
+      const body = JSON.parse(calls[0].init!.body as string);
+      expect(body.start).toEqual({ date: "2026-06-14" });
+      expect(body.end).toEqual({ date: "2026-06-14" });
+    });
+
+    it("returns null on non-ok response", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}, 403));
+      expect(await insertEvent(env, "x", "2026-06-14")).toBeNull();
+    });
+  });
+
+  describe("updateEventDateTime", () => {
+    it("returns true on success (timed)", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() => json({ id: "evt-1" }));
+
+      const ok = await updateEventDateTime(env, "evt-1", "2026-06-15T11:00");
+      expect(ok).toBe(true);
+      expect(calls[0].init?.method).toBe("PATCH");
+      const body = JSON.parse(calls[0].init!.body as string);
+      expect(body.start.timeZone).toBe("Asia/Tokyo");
+      expect(body.summary).toBeUndefined();
+    });
+
+    it("returns true on success (all-day)", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() => json({}));
+      const ok = await updateEventDateTime(env, "evt-1", "2026-06-15");
+      expect(ok).toBe(true);
+      const body = JSON.parse(calls[0].init!.body as string);
+      expect(body.start).toEqual({ date: "2026-06-15" });
+      expect(body.end).toEqual({ date: "2026-06-15" });
+    });
+
+    it("returns false on 404", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}, 404));
+      expect(await updateEventDateTime(env, "evt-x", "2026-06-15")).toBe(false);
+    });
+
+    it("returns false on 410", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}, 410));
+      expect(await updateEventDateTime(env, "evt-x", "2026-06-15")).toBe(false);
+    });
+
+    it("throws on other non-ok status", async () => {
+      const env = createMockEnv();
+      stubFetch(() => json({}, 500));
+      await expect(updateEventDateTime(env, "evt-x", "2026-06-15")).rejects.toThrow("500");
+    });
+  });
+
+  describe("deleteEvent", () => {
+    it("issues a DELETE to the event URL", async () => {
+      const env = createMockEnv();
+      const { calls } = stubFetch(() => new Response(null, { status: 204 }));
+
+      await deleteEvent(env, "evt-1");
+      expect(calls[0].url).toContain("/events/evt-1");
+      expect(calls[0].init?.method).toBe("DELETE");
+      expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer test-access-token" });
+    });
+  });
+});

--- a/cf-worker/test/unit/clients/gcal-api.test.ts
+++ b/cf-worker/test/unit/clients/gcal-api.test.ts
@@ -9,6 +9,7 @@ import { createMockEnv } from "../../helpers/mocks.js";
 
 vi.mock("../../../src/clients/google-auth.js", () => ({
   getAccessToken: vi.fn().mockResolvedValue("test-access-token"),
+  authHeader: (token: string) => ({ Authorization: `Bearer ${token}` }),
 }));
 
 type FetchCall = { url: string; init?: RequestInit };

--- a/cf-worker/test/unit/handlers/office-leave.test.ts
+++ b/cf-worker/test/unit/handlers/office-leave.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleOfficeLeave } from "../../../src/handlers/office-leave.js";
+import { createMockEnv, sampleTasks } from "../../helpers/mocks.js";
+
+vi.mock("../../../src/utils/holiday.js", () => ({
+  isHoliday: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../../../src/clients/notion.js", () => ({
+  getOpenTasks: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/anthropic.js", () => ({
+  selectOfficeLeaveNotifications: vi.fn(),
+}));
+
+vi.mock("../../../src/clients/telegram.js", () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("handleOfficeLeave", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array without calling Claude when no open tasks", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectOfficeLeaveNotifications } = await import("../../../src/clients/anthropic.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await handleOfficeLeave(env);
+    expect(result).toEqual([]);
+    expect(selectOfficeLeaveNotifications).not.toHaveBeenCalled();
+  });
+
+  it("passes tasks to Claude and sends Telegram message with priority icons", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectOfficeLeaveNotifications } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectOfficeLeaveNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { title: "請求書を提出", priority: "high" },
+      { title: "帰りに郵便局", priority: "medium" },
+      { title: "資料の整理", priority: "low" },
+    ]);
+
+    const result = await handleOfficeLeave(env);
+
+    expect(result).toHaveLength(3);
+    expect(selectOfficeLeaveNotifications).toHaveBeenCalledWith(env, sampleTasks(), expect.any(String));
+
+    const message = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(message).toContain("🏢");
+    expect(message).toContain("🔴");
+    expect(message).toContain("🟡");
+    expect(message).toContain("🟢");
+    expect(message).toContain("請求書を提出");
+  });
+
+  it("skips Telegram when Claude returns no notifications", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectOfficeLeaveNotifications } = await import("../../../src/clients/anthropic.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectOfficeLeaveNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const result = await handleOfficeLeave(env);
+    expect(result).toEqual([]);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array on holiday without calling any downstream", async () => {
+    const env = createMockEnv();
+    const { isHoliday } = await import("../../../src/utils/holiday.js");
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { sendMessage } = await import("../../../src/clients/telegram.js");
+
+    (isHoliday as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+
+    const result = await handleOfficeLeave(env);
+    expect(result).toEqual([]);
+    expect(getOpenTasks).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("passes JST datetime string to Claude", async () => {
+    const env = createMockEnv();
+    const { getOpenTasks } = await import("../../../src/clients/notion.js");
+    const { selectOfficeLeaveNotifications } = await import("../../../src/clients/anthropic.js");
+
+    (getOpenTasks as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTasks());
+    (selectOfficeLeaveNotifications as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await handleOfficeLeave(env);
+
+    const jstArg = (selectOfficeLeaveNotifications as ReturnType<typeof vi.fn>).mock.calls[0][2] as string;
+    expect(jstArg).toMatch(/\d{4}/);
+    expect(jstArg).toMatch(/\d{2}:\d{2}/);
+  });
+});

--- a/cf-worker/test/unit/utils/jst.test.ts
+++ b/cf-worker/test/unit/utils/jst.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { jstNow, jstDateStr, jstDateTimeStr, toDateStr } from "../../../src/utils/jst.js";
+
+describe("jst utils", () => {
+  it("jstDateStr returns YYYY-MM-DD", () => {
+    expect(jstDateStr()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("jstDateStr matches sv-SE Asia/Tokyo formatting", () => {
+    const expected = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+    expect(jstDateStr()).toBe(expected);
+  });
+
+  it("jstDateTimeStr contains date and HH:MM (24h)", () => {
+    const s = jstDateTimeStr();
+    expect(s).toMatch(/\d{4}/);
+    expect(s).toMatch(/\d{2}:\d{2}/);
+  });
+
+  it("jstNow returns a Date", () => {
+    expect(jstNow()).toBeInstanceOf(Date);
+    expect(Number.isNaN(jstNow().getTime())).toBe(false);
+  });
+
+  it("toDateStr returns the UTC date portion of a Date", () => {
+    const d = new Date("2026-06-14T15:30:00.000Z");
+    expect(toDateStr(d)).toBe("2026-06-14");
+  });
+});

--- a/cf-worker/test/unit/utils/task.test.ts
+++ b/cf-worker/test/unit/utils/task.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { PRIORITY_ORDER, PRIORITY_ICON, bestPriorityTask } from "../../../src/utils/task.js";
+
+describe("task utils", () => {
+  it("PRIORITY_ORDER ranks high < medium < low", () => {
+    expect(PRIORITY_ORDER.high).toBe(0);
+    expect(PRIORITY_ORDER.medium).toBe(1);
+    expect(PRIORITY_ORDER.low).toBe(2);
+  });
+
+  it("PRIORITY_ICON maps each priority", () => {
+    expect(PRIORITY_ICON.high).toBe("🔴");
+    expect(PRIORITY_ICON.medium).toBe("🟡");
+    expect(PRIORITY_ICON.low).toBe("🟢");
+  });
+
+  it("bestPriorityTask picks the highest priority", () => {
+    const tasks = [
+      { priority: "low", id: 1 },
+      { priority: "high", id: 2 },
+      { priority: "medium", id: 3 },
+    ];
+    expect(bestPriorityTask(tasks).id).toBe(2);
+  });
+
+  it("bestPriorityTask returns the first on ties (<=)", () => {
+    const tasks = [
+      { priority: "medium", id: 1 },
+      { priority: "medium", id: 2 },
+    ];
+    expect(bestPriorityTask(tasks).id).toBe(1);
+  });
+
+  it("bestPriorityTask treats unknown priority as medium", () => {
+    const tasks = [
+      { priority: "weird", id: 1 },
+      { priority: "low", id: 2 },
+    ];
+    // unknown(1) <= low(2) → keeps the unknown one
+    expect(bestPriorityTask(tasks).id).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

`cf-worker/src/` に散在していた重複コードを共通ユーティリティ／ヘルパーへ集約するリファクタリング。**挙動は一切変えない**ことが前提で、共通化前に未カバー箇所へ特性テストを追加し、リファクタ前後で同一テストが緑であることをもって等価性を担保した。

> ⚠️ このブランチは未マージの #49 (`feat/office-leave-api`) にスタックしています。base を `feat/office-leave-api` にしているため差分は本リファクタ分のみ。#49 マージ後に master へ向け直し可能です。

## 変更内容（コミット単位）

| Step | 内容 |
|---|---|
| 0 | 未カバーだった `office-leave` ハンドラ・`gcal-api` クライアントに特性テスト追加（リファクタ前の安全網） |
| 1 | `utils/jst.ts` 抽出（`jstNow`/`jstDateStr`/`jstDateTimeStr`/`toDateStr`）。en-US/sv-SE/ja-JP 系の JST 日時式を集約 |
| 2 | `utils/task.ts` 抽出（`PRIORITY_ORDER`/`PRIORITY_ICON`/`bestPriorityTask`）。優先度 order/icon の重複と最優先選択を集約 |
| 3 | `anthropic.ts`: `extractJsonArray`/`extractJsonObject` で JSON 抽出 5 箇所を共通化。`select{Home,Office}` を共通 private に集約（export 不変） |
| 4 | `notion.ts`: `patchNotionPage`/`fetchTaskPage` 抽出。throw / fire-and-forget の差は呼び出し側に保持 |
| 5 | Google クライアントの `authHeader` を `google-auth.ts` に集約 |
| 6 | `handlers/notification-trigger.ts` に帰宅/退社の共通フローを抽出。両ハンドラは薄いラッパに |

## 挙動不変の担保

- 置換は**元の式と完全に同一の挙動を持つ箇所のみ**。意味の異なる日付計算（JST vs UTC）は統合せず維持。
- `holiday.ts` は別実装の private ヘルパーを持つため統合対象外。
- HTML ストリッパー（gmail vs telegram）は実装が非同一・用途が別のため意図的に未統合。
- 全 **196 件**（既存 166 + 新規 30）緑。`tsc --noEmit` は src にエラーなし（既存のテスト fixture import-assertion 警告のみ）。
- `/code-review`（high effort, 2 finder + cross-file/reuse）で **findings ゼロ**。

## 検証

```bash
cd cf-worker && npm run test   # 196 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)