### PR TITLE
perf: ジオフェンス状態変化時のみ KV 書き込みに最適化

### DIFF
--- a/cf-worker/src/handlers/location.ts
+++ b/cf-worker/src/handlers/location.ts
@@ -57,8 +57,11 @@ export async function handleOwnTracksLocation(
       const prev = await getGeofenceState(env, region.id);
       const transition = detectTransition(prev, current);
 
-      // 状態を更新（遷移有無に関わらず最新状態を保持）
-      await setGeofenceState(env, region.id, current);
+      // 状態が変化した時だけ KV へ書き込む（KV 書き込み無料枠の節約）
+      // null（初回）→ "inside"/"outside" も current !== prev として必ず1回保存される
+      if (current !== prev) {
+        await setGeofenceState(env, region.id, current);
+      }
 
       if (!transition) return;
 

--- a/cf-worker/test/integration/owntracks.test.ts
+++ b/cf-worker/test/integration/owntracks.test.ts
@@ -175,6 +175,37 @@ describe("POST /owntracks", () => {
     expect((sendMessage as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountAfterEnter);
   });
 
+  it("同一状態が続く場合は KV へ書き込まない（write 最適化）", async () => {
+    const env = createMockEnv();
+    await env.AGENT_KV.put("geofence:regions", JSON.stringify([HOME_REGION]));
+
+    const putSpy = vi.spyOn(env.AGENT_KV, "put");
+
+    // 1通目（圏外）: 初回なので geofence:state:home への書き込みが発生する
+    await worker.fetch(
+      ownTracksRequest(locationPayload(OUTSIDE_HOME.lat, OUTSIDE_HOME.lon), env.OWNTRACKS_TOKEN),
+      env,
+    );
+    const writesAfterFirst = putSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith("geofence:state:"),
+    ).length;
+    expect(writesAfterFirst).toBe(1); // 初回は必ず書く
+
+    // 2通目・3通目（同じく圏外）: 状態変化なし → 書き込みなし
+    await worker.fetch(
+      ownTracksRequest(locationPayload(OUTSIDE_HOME.lat, OUTSIDE_HOME.lon), env.OWNTRACKS_TOKEN),
+      env,
+    );
+    await worker.fetch(
+      ownTracksRequest(locationPayload(OUTSIDE_HOME.lat, OUTSIDE_HOME.lon), env.OWNTRACKS_TOKEN),
+      env,
+    );
+    const writesAfterRepeat = putSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith("geofence:state:"),
+    ).length;
+    expect(writesAfterRepeat).toBe(1); // 増えていない
+  });
+
   it("gym リージョンの telegram_notify がカスタム文言で送られる", async () => {
     const { sendMessage } = await import("../../src/clients/telegram.js");
 


### PR DESCRIPTION
## Summary

- `cf-worker/src/handlers/location.ts` で `setGeofenceState` を呼ぶ前に `if (current !== prev)` ガードを追加
- ジオフェンス状態が変化したときだけ KV へ書き込むようにし、無駄な write を排除
- KV 書き込み消費量: **POST 数 × リージョン数 / 日 → 実際の遷移回数（1 日数回）** に削減

### Before / After

| | Before | After |
|---|---|---|
| KV writes / 日 | 500 POST × 2 region = **1,000**（無料枠上限） | 遷移回数 × region = **数件** |
| 通知挙動 | 変わらず | 変わらず |

## Test plan

- [x] 既存テスト全パス（`owntracks.test.ts` 8 tests ✅）
- [x] 追加テスト: 同一状態の連続 POST で `geofence:state:*` への KV put が増えないことを検証
- [x] `task-formatter.test.ts` の 3 失敗は既存の不具合（日付タイムゾーンのズレ）で本 PR と無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)