### PR TITLE
feat: ジオフェンス遷移と通知結果の監査ログを追加

### DIFF
--- a/cf-worker/src/handlers/location.ts
+++ b/cf-worker/src/handlers/location.ts
@@ -65,6 +65,18 @@ export async function handleOwnTracksLocation(
 
       if (!transition) return;
 
+      console.log(
+        JSON.stringify({
+          event: "geofence_transition",
+          regionId: region.id,
+          transition,
+          distanceM: Math.round(distanceM),
+          lat,
+          lon,
+          tst,
+        }),
+      );
+
       const ctx = { regionId: region.id, transition, location: { lat, lon, tst } };
       const spec = transition === "enter" ? region.onEnter : region.onLeave;
 

--- a/cf-worker/src/handlers/notification-trigger.ts
+++ b/cf-worker/src/handlers/notification-trigger.ts
@@ -27,14 +27,23 @@ export async function runNotificationTrigger(
   select: SelectFn,
   header: string,
 ): Promise<HomeArrivalNotification[]> {
-  if (await isHoliday()) return [];
+  if (await isHoliday()) {
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "skipped_holiday" }));
+    return [];
+  }
 
   const tasks = await getOpenTasks(env);
-  if (tasks.length === 0) return [];
+  if (tasks.length === 0) {
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "skipped_no_tasks" }));
+    return [];
+  }
 
   const notifications = await select(env, tasks, jstDateTimeStr());
   if (notifications.length > 0) {
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "sent", count: notifications.length }));
     await sendMessage(env, buildTelegramMessage(header, notifications));
+  } else {
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "skipped_no_selection" }));
   }
 
   return notifications;

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -32,5 +32,8 @@ database_id = "ba5c15ff-8e0e-4b86-b020-f1c4cb5975a3"
 # GOOGLE_CLIENT_SECRET
 # GOOGLE_REFRESH_TOKEN
 
+[observability]
+enabled = true
+
 # optional vars (set via wrangler.toml [vars] or secret)
 # GMAIL_ACCOUNT_INDEX=0  # Gmail の u/N のN（複数アカウント時に変更）


### PR DESCRIPTION
## Summary

- `wrangler.toml` に `[observability] enabled = true` を追加し Workers Logs を有効化
- `location.ts`: enter/leave 発火時に `geofence_transition` イベントを JSON で `console.log`（regionId・transition・distanceM・lat/lon/tst を含む）
- `notification-trigger.ts`: 各分岐で `notification_trigger` イベントをログ出力
  - `skipped_holiday` — 週末・祝日スキップ
  - `skipped_no_tasks` — 未完了タスク 0 件
  - `skipped_no_selection` — LLM が通知0件を選定
  - `sent` + `count` — 実際に Telegram 送信

## 背景

土曜の帰宅で通知が届かなかった原因調査を行い、ジオフェンス検知は正常（enter 発火・KV state 更新済み）で週末スキップ仕様が原因と判明。仕様は変更しないが、今後同種の調査を Workers Logs だけで完結できるよう監査ログを追加した。

## Test plan

- [x] `vitest run` — 25 ファイル 222 テスト全通過
- [x] テスト出力でログ JSON が全 4 パターン（sent / skipped_holiday / skipped_no_tasks / skipped_no_selection）と geofence_transition（enter/leave）が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)