### PR TITLE
fix: add console output to insertAppLog for Logpush compatibility

### DIFF
--- a/cf-worker/src/storage/d1.ts
+++ b/cf-worker/src/storage/d1.ts
@@ -140,6 +140,13 @@ export async function cleanOldLocations(env: Env): Promise<void> {
 
 // app_logs
 export async function insertAppLog(env: Env, level: string, message: string, data?: any): Promise<void> {
+  // Cloudflare Logpush (Workers Trace Events) 向けに標準出力にも出す
+  if (level === "error") {
+    console.error(`[${level}] ${message}`, data ? JSON.stringify(data) : "");
+  } else {
+    console.info(`[${level}] ${message}`, data ? JSON.stringify(data) : "");
+  }
+
   try {
     await env.AGENT_DB.prepare(
       "INSERT INTO app_logs (level, message, data) VALUES (?, ?, ?)"


### PR DESCRIPTION
Logpush needs console output to trace events.