### PR TITLE
feat: notify even when no tasks are found for geofence actions

### DIFF
--- a/cf-worker/src/handlers/notification-trigger.ts
+++ b/cf-worker/src/handlers/notification-trigger.ts
@@ -34,7 +34,8 @@ export async function runNotificationTrigger(
 
   const tasks = await getOpenTasks(env);
   if (tasks.length === 0) {
-    console.log(JSON.stringify({ event: "notification_trigger", header, result: "skipped_no_tasks" }));
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "sent_empty_no_tasks" }));
+    await sendMessage(env, `${header}\n\n該当するタスクはありません。お疲れ様でした！`);
     return [];
   }
 
@@ -43,7 +44,8 @@ export async function runNotificationTrigger(
     console.log(JSON.stringify({ event: "notification_trigger", header, result: "sent", count: notifications.length }));
     await sendMessage(env, buildTelegramMessage(header, notifications));
   } else {
-    console.log(JSON.stringify({ event: "notification_trigger", header, result: "skipped_no_selection" }));
+    console.log(JSON.stringify({ event: "notification_trigger", header, result: "sent_empty_no_selection" }));
+    await sendMessage(env, `${header}\n\n該当するタスクはありません。お疲れ様でした！`);
   }
 
   return notifications;

--- a/cf-worker/test/integration/home-arrival.test.ts
+++ b/cf-worker/test/integration/home-arrival.test.ts
@@ -75,7 +75,7 @@ describe("/home-arrival ingress", () => {
     expect(resp.status).toBe(200);
     const body = await resp.json<{ notifications: unknown[] }>();
     expect(body.notifications).toHaveLength(0);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("該当するタスクはありません"));
   });
 
   it("returns 500 with empty notifications when handler throws", async () => {

--- a/cf-worker/test/unit/handlers/home-arrival.test.ts
+++ b/cf-worker/test/unit/handlers/home-arrival.test.ts
@@ -72,7 +72,7 @@ describe("handleHomeArrival", () => {
 
     const result = await handleHomeArrival(env);
     expect(result).toEqual([]);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("該当するタスクはありません"));
   });
 
   it("returns empty array on holiday without calling any downstream", async () => {

--- a/cf-worker/test/unit/handlers/office-leave.test.ts
+++ b/cf-worker/test/unit/handlers/office-leave.test.ts
@@ -72,7 +72,7 @@ describe("handleOfficeLeave", () => {
 
     const result = await handleOfficeLeave(env);
     expect(result).toEqual([]);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(env, expect.stringContaining("該当するタスクはありません"));
   });
 
   it("returns empty array on holiday without calling any downstream", async () => {


### PR DESCRIPTION
Geofence アクション（帰宅・退社など）で、該当するタスクが存在しない場合でもスキップせずに空の通知を送るように変更。